### PR TITLE
Replace include of inttypes.h with cinttypes.

### DIFF
--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -14,6 +14,7 @@
 
 #include <array>
 #include <cmath>
+#include <cinttypes>
 #include <fstream>
 #include <iostream>
 #include <limits>
@@ -27,7 +28,6 @@
 #include <vector>
 
 #include <fcntl.h>
-#include <inttypes.h>
 #include <limits.h>
 #include <math.h>
 #include <signal.h>


### PR DESCRIPTION
Fixes build problem on GCC 6.2, related to PRIx64.

```
g++-6.2 -std=c++11 -ffunction-sections -fdata-sections -Wall -Wno-sign-compare -g -I third_party/re2 -I. -Isrc -O2   -c -o src/bloaty.o src/bloaty.cc
src/bloaty.cc: In member function 'void bloaty::RangeMap::AddDualRange(uint64_t, uint64_t, uint64_t, const string&)':
src/bloaty.cc:952:43: error: expected ')' before 'PRIx64'
                 "WARN: adding mapping [%" PRIx64 "x, %" PRIx64 "x] for label"
                                           ^~~~~~
```