### PR TITLE
Add a using declaration for functions used from cmath.

### DIFF
--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -53,6 +53,9 @@
   }
 #define CHECK_RETURN(call) if (!(call)) { return false; }
 
+using std::isnan;
+using std::isinf;
+
 namespace bloaty {
 
 size_t max_label_len = 80;


### PR DESCRIPTION
Add using directives for the functions used in <cmath>

This was causing compilation to fail with G++ and Clang++ on Ubuntu 16.0.4.