### PR TITLE
Add `#define __STDC_LIMIT_MACROS` to bloaty.h

### DIFF
--- a/src/bloaty.h
+++ b/src/bloaty.h
@@ -20,6 +20,7 @@
 #define BLOATY_H_
 
 #include <stdlib.h>
+#define __STDC_LIMIT_MACROS
 #include <stdint.h>
 #ifdef __FreeBSD__
 #include <sys/endian.h>


### PR DESCRIPTION
This prevents a compile error due to an undefined symbol UINT64_MAX
on platforms where stdint.h doesn't otherwise define it.