### PR TITLE
Switch order of touch args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ third_party/re2/obj/libre2.a: third_party/re2/Makefile
 third%party/re2/Makefile third%party/re2/re2/re2.h third%party/googletest/CMakeLists.txt third%party/libFuzzer/build.sh: .gitmodules
 	git submodule init && git submodule update
 	@# Ensure .gitmodules cannot be newer
-	touch .gitmodules -r $@
+	touch -r .gitmodules $@
 
 clean:
 	rm -f bloaty src/*.o src/*.a


### PR DESCRIPTION
so as not to create a `-r` file on OS X.

Without this if I do a fresh checkout on OS X and then`make`, I end up with a `-r` file:

```
$ ls -l -- -r
-rw-r--r--  1 abramowi  wheel  0 Mar 29 17:44 -r
```