### PR TITLE
Warn when we can't read compressed debug info.

### DIFF
--- a/src/bloaty.h
+++ b/src/bloaty.h
@@ -174,6 +174,12 @@ struct File {
   StringPiece debug_abbrev;
   StringPiece debug_aranges;
   StringPiece debug_line;
+  StringPiece zdebug_info;
+  StringPiece zdebug_types;
+  StringPiece zdebug_str;
+  StringPiece zdebug_abbrev;
+  StringPiece zdebug_aranges;
+  StringPiece zdebug_line;
 };
 
 }  // namespace dwarf

--- a/src/dwarf.cc
+++ b/src/dwarf.cc
@@ -1780,7 +1780,11 @@ static bool ReadDWARFDebugInfo(const dwarf::File& file,
 bool ReadDWARFCompileUnits(const dwarf::File& file, const SymbolTable& symtab,
                            RangeSink* sink) {
   if (!file.debug_info.size()) {
-    fprintf(stderr, "bloaty: missing debug info\n");
+    if (file.zdebug_info.size()) {
+      fprintf(stderr, "bloaty: can't read compressed debug info: \n");
+    } else {
+      fprintf(stderr, "bloaty: missing debug info\n");
+    }
     return false;
   }
 
@@ -1805,7 +1809,11 @@ static std::string LineInfoKey(const std::string& file, uint32_t line,
 bool ReadDWARFInlines(const dwarf::File& file, RangeSink* sink,
                       bool include_line) {
   if (!file.debug_info.size() || !file.debug_line.size()) {
-    fprintf(stderr, "bloaty: missing debug info\n");
+    if (file.zdebug_info.size() && file.zdebug_line.size()) {
+      fprintf(stderr, "bloaty: can't read compressed debug info: \n");
+    } else {
+      fprintf(stderr, "bloaty: missing debug info\n");
+    }
     return false;
   }
 

--- a/src/elf.cc
+++ b/src/elf.cc
@@ -829,6 +829,16 @@ static bool ReadDWARFSections(const ElfFile& elf, dwarf::File* dwarf) {
       dwarf->debug_abbrev = section.contents();
     } else if (name == ".debug_line") {
       dwarf->debug_line = section.contents();
+    } else if (name == ".zdebug_aranges") {
+      dwarf->zdebug_aranges = section.contents();
+    } else if (name == ".zdebug_str") {
+      dwarf->zdebug_str = section.contents();
+    } else if (name == ".zdebug_info") {
+      dwarf->zdebug_info = section.contents();
+    } else if (name == ".zdebug_abbrev") {
+      dwarf->zdebug_abbrev = section.contents();
+    } else if (name == ".zdebug_line") {
+      dwarf->zdebug_line = section.contents();
     }
   }
 


### PR DESCRIPTION
This just improves the error message slightly.