### PR TITLE
Use exception handling internally to propagate errors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,19 +12,28 @@ set(CMAKE_CXX_FLAGS "-std=c++11 -W -Wall -Wno-sign-compare")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG(-fdiagnostics-color=always SUPPORTS_COLOR_ALWAYS)
+if(SUPPORTS_COLOR_ALWAYS)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+endif()
+
 add_library(libbloaty
     src/bloaty.cc
     src/dwarf.cc
     src/elf.cc
     src/macho.cc
     # Until Abseil has a proper CMake build system
-    third_party/abseil-cpp/absl/base/internal/throw_delegate.cc
     third_party/abseil-cpp/absl/base/internal/raw_logging.cc # Grrrr...
+    third_party/abseil-cpp/absl/base/internal/throw_delegate.cc
     third_party/abseil-cpp/absl/strings/ascii.cc
+    third_party/abseil-cpp/absl/strings/escaping.cc
     third_party/abseil-cpp/absl/strings/internal/memutil.cc
+    third_party/abseil-cpp/absl/strings/internal/utf8.cc
     third_party/abseil-cpp/absl/strings/numbers.cc
     third_party/abseil-cpp/absl/strings/str_cat.cc
     third_party/abseil-cpp/absl/strings/string_view.cc
+    third_party/abseil-cpp/absl/strings/substitute.cc
     )
 
 add_executable(bloaty src/main.cc)

--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -121,7 +121,7 @@ void CheckedAdd(A* accum, B val) {
   static_assert(std::is_signed<A>::value, "requires signed A");
   static_assert(sizeof(A) == sizeof(B), "requires integers of the same type");
 #if ABSL_HAVE_BUILTIN(__builtin_add_overflow)
-  if (!__builtin_add_overflow(*accum, val, accum)) {
+  if (__builtin_add_overflow(*accum, val, accum)) {
     THROW("integer overflow");
   }
 #else

--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -40,6 +40,7 @@
 
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
+#include "absl/strings/substitute.h"
 #include "re2/re2.h"
 #include <assert.h>
 
@@ -54,7 +55,13 @@ using absl::string_view;
     perror(#call " " __FILE__ ":" TOSTRING(__LINE__)); \
     exit(1); \
   }
-#define CHECK_RETURN(call) if (!(call)) { return false; }
+
+static void Throw(const char *str, int line) {
+  throw bloaty::Error(str, __FILE__, line);
+}
+
+#define THROW(msg) Throw(msg, __LINE__)
+#define THROWF(...) Throw(absl::Substitute(__VA_ARGS__).c_str(), __LINE__)
 
 namespace bloaty {
 
@@ -109,9 +116,11 @@ int SignOf(long val) {
 }
 
 template <typename A, typename B>
-bool CheckedAdd(A* accum, B val) {
+void CheckedAdd(A* accum, B val) {
   // TODO(haberman): add a portable version of this.
-  return !__builtin_add_overflow(*accum, val, accum);
+  if (__builtin_add_overflow(*accum, val, accum)) {
+    THROW("integer overflow");
+  }
 }
 
 std::string CSVEscape(string_view str) {
@@ -250,7 +259,6 @@ class NameStripper {
         ++nesting;
       }
     }
-
 
     stripped_ = &name;
     return false;
@@ -435,27 +443,25 @@ class Rollup {
  public:
   Rollup() {}
 
-  bool AddSizes(const std::vector<std::string> names,
+  void AddSizes(const std::vector<std::string> names,
                 uint64_t size, bool is_vmsize) {
     // We start at 1 to exclude the base map (see base_map_).
-    return AddInternal(names, 1, size, is_vmsize);
+    AddInternal(names, 1, size, is_vmsize);
   }
 
   // Prints a graphical representation of the rollup.
-  bool ComputeWithBase(int row_limit, RollupOutput* row) const {
-    return ComputeWithBase(nullptr, row_limit, row);
+  void ComputeWithBase(int row_limit, RollupOutput* row) const {
+    ComputeWithBase(nullptr, row_limit, row);
   }
 
-  bool ComputeWithBase(Rollup* base, int row_limit, RollupOutput* output) const {
+  void ComputeWithBase(Rollup* base, int row_limit, RollupOutput* output) const {
     RollupRow* row = &output->toplevel_row_;
     row->vmsize = vm_total_;
     row->filesize = file_total_;
     row->vmpercent = 100;
     row->filepercent = 100;
     output->longest_label_ = 0;
-    CHECK_RETURN(
-        CreateRows(0, row, &output->longest_label_, base, row_limit, true));
-    return true;
+    CreateRows(0, row, &output->longest_label_, base, row_limit, true);
   }
 
   // Subtract the values in "other" from this.
@@ -493,35 +499,34 @@ class Rollup {
 
   // Adds "size" bytes to the rollup under the label names[i].
   // If there are more entries names[i+1, i+2, etc] add them to sub-rollups.
-  bool AddInternal(const std::vector<std::string> names, size_t i,
+  void AddInternal(const std::vector<std::string> names, size_t i,
                    uint64_t size, bool is_vmsize) {
     if (is_vmsize) {
-      CHECK_RETURN(CheckedAdd(&vm_total_, size));
+      CheckedAdd(&vm_total_, size);
     } else {
-      CHECK_RETURN(CheckedAdd(&file_total_, size));
+      CheckedAdd(&file_total_, size);
     }
     if (i < names.size()) {
       auto& child = children_[names[i]];
       if (child.get() == nullptr) {
         child.reset(new Rollup());
       }
-      CHECK_RETURN(child->AddInternal(names, i + 1, size, is_vmsize));
+      child->AddInternal(names, i + 1, size, is_vmsize);
     }
-    return true;
   }
 
   static double Percent(ssize_t part, size_t whole) {
     return static_cast<double>(part) / static_cast<double>(whole) * 100;
   }
 
-  bool CreateRows(size_t indent, RollupRow* row, size_t* longest_label,
+  void CreateRows(size_t indent, RollupRow* row, size_t* longest_label,
                   const Rollup* base, int row_limit, bool is_toplevel) const;
-  bool ComputeRows(size_t indent, RollupRow* row,
+  void ComputeRows(size_t indent, RollupRow* row,
                    std::vector<RollupRow>* children, size_t* longest_label,
                    const Rollup* base, int row_limit, bool is_toplevel) const;
 };
 
-bool Rollup::CreateRows(size_t indent, RollupRow* row, size_t* longest_label,
+void Rollup::CreateRows(size_t indent, RollupRow* row, size_t* longest_label,
                         const Rollup* base, int row_limit,
                         bool is_toplevel) const {
   if (base) {
@@ -551,18 +556,17 @@ bool Rollup::CreateRows(size_t indent, RollupRow* row, size_t* longest_label,
     }
   }
 
-  CHECK_RETURN(ComputeRows(indent, row, &row->sorted_children, longest_label,
-                           base, row_limit, is_toplevel));
-  CHECK_RETURN(ComputeRows(indent, row, &row->shrinking, longest_label, base,
-                           row_limit, is_toplevel));
-  CHECK_RETURN(ComputeRows(indent, row, &row->mixed, longest_label, base,
-                           row_limit, is_toplevel));
-  return true;
+  ComputeRows(indent, row, &row->sorted_children, longest_label, base,
+              row_limit, is_toplevel);
+  ComputeRows(indent, row, &row->shrinking, longest_label, base, row_limit,
+              is_toplevel);
+  ComputeRows(indent, row, &row->mixed, longest_label, base, row_limit,
+              is_toplevel);
 }
 
 Rollup* Rollup::empty_;
 
-bool Rollup::ComputeRows(size_t indent, RollupRow* row,
+void Rollup::ComputeRows(size_t indent, RollupRow* row,
                          std::vector<RollupRow>* children,
                          size_t* longest_label, const Rollup* base,
                          int row_limit, bool is_toplevel) const {
@@ -582,7 +586,7 @@ bool Rollup::ComputeRows(size_t indent, RollupRow* row,
   }
 
   if (child_rows.empty()) {
-    return true;
+    return;
   }
 
   // Our overall sorting rank.
@@ -633,14 +637,13 @@ bool Rollup::ComputeRows(size_t indent, RollupRow* row,
   // out to "others_row".
   size_t i = child_rows.size() - 1;
   while (i >= row_limit) {
-    CHECK_RETURN(CheckedAdd(&others_row.vmsize, child_rows[i].vmsize));
-    CHECK_RETURN(CheckedAdd(&others_row.filesize, child_rows[i].filesize));
+    CheckedAdd(&others_row.vmsize, child_rows[i].vmsize);
+    CheckedAdd(&others_row.filesize, child_rows[i].filesize);
     if (base) {
       auto it = base->children_.find(child_rows[i].name);
       if (it != base->children_.end()) {
-        CHECK_RETURN(CheckedAdd(&others_base.vm_total_, it->second->vm_total_));
-        CHECK_RETURN(
-            CheckedAdd(&others_base.file_total_, it->second->file_total_));
+        CheckedAdd(&others_base.vm_total_, it->second->vm_total_);
+        CheckedAdd(&others_base.file_total_, it->second->file_total_);
       }
     }
 
@@ -650,8 +653,8 @@ bool Rollup::ComputeRows(size_t indent, RollupRow* row,
 
   if (std::abs(others_row.vmsize) > 0 || std::abs(others_row.filesize) > 0) {
     child_rows.push_back(others_row);
-    CHECK_RETURN(CheckedAdd(&others_rollup.vm_total_, others_row.vmsize));
-    CHECK_RETURN(CheckedAdd(&others_rollup.file_total_, others_row.filesize));
+    CheckedAdd(&others_rollup.vm_total_, others_row.vmsize);
+    CheckedAdd(&others_rollup.file_total_, others_row.filesize);
   }
 
   // Sort all rows (including "other") and include sort by name.
@@ -680,9 +683,7 @@ bool Rollup::ComputeRows(size_t indent, RollupRow* row,
     } else {
       auto it = children_.find(child_row.name);
       if (it == children_.end()) {
-        std::cerr << "Should never happen, couldn't find name: "
-                  << child_row.name << "\n";
-        return false;
+        THROWF("internal error, couldn't find name $0", child_row.name);
       }
       child_rollup = it->second.get();
       assert(child_rollup);
@@ -703,10 +704,9 @@ bool Rollup::ComputeRows(size_t indent, RollupRow* row,
         std::min(stripper.stripped().size(), max_label_len);
     child_row.name = stripper.stripped();
     *longest_label = std::max(*longest_label, allowed_label_len + indent);
-    CHECK_RETURN(child_rollup->CreateRows(indent + 4, &child_row, longest_label,
-                                          child_base, row_limit, false));
+    child_rollup->CreateRows(indent + 4, &child_row, longest_label, child_base,
+                             row_limit, false);
   }
-  return true;
 }
 
 
@@ -1111,7 +1111,7 @@ void RangeMap::AddRangeWithTranslation(uint64_t addr, uint64_t size,
 }
 
 template <class Func>
-bool RangeMap::ComputeRollup(const std::vector<const RangeMap*>& range_maps,
+void RangeMap::ComputeRollup(const std::vector<const RangeMap*>& range_maps,
                              const std::string& filename,
                              int filename_position, Func func) {
   assert(range_maps.size() > 0);
@@ -1198,12 +1198,11 @@ bool RangeMap::ComputeRollup(const std::vector<const RangeMap*>& range_maps,
     }
 
     if (have_data) {
-      CHECK_RETURN(func(keys, current, next_break));
+      func(keys, current, next_break);
     }
 
     current = next_break;
   }
-  return true;
 }
 
 
@@ -1246,60 +1245,63 @@ std::string MemoryMap::ApplyNameRegexes(string_view name) {
 
 class MmapInputFile : public InputFile {
  public:
-  MmapInputFile(const std::string& filename) : InputFile(filename) {}
+  MmapInputFile(const std::string& filename);
   ~MmapInputFile() override;
-
-  bool Open();
 
  private:
   BLOATY_DISALLOW_COPY_AND_ASSIGN(MmapInputFile);
 };
 
-bool MmapInputFile::Open() {
-  int fd = open(filename().c_str(), O_RDONLY);
+class FileDescriptor {
+ public:
+  FileDescriptor(int fd) : fd_(fd) {}
+
+  ~FileDescriptor() {
+    if (fd_ >= 0 && close(fd_) < 0) {
+      fprintf(stderr, "bloaty: error calling close(): %s\n", strerror(errno));
+    }
+  }
+
+  int fd() { return fd_; }
+
+ private:
+  int fd_;
+};
+
+MmapInputFile::MmapInputFile(const std::string& filename)
+    : InputFile(filename) {
+  FileDescriptor fd(open(filename.c_str(), O_RDONLY));
   struct stat buf;
   const char *map;
 
-  if (fd < 0) {
-    fprintf(stderr, "bloaty: couldn't open file '%s': %s\n", filename().c_str(),
-            strerror(errno));
-    return false;
+  if (fd.fd() < 0) {
+    THROWF("couldn't open file '$0': $1", filename, strerror(errno));
   }
 
-  if (fstat(fd, &buf) < 0) {
-    fprintf(stderr, "bloaty: couldn't stat file '%s': %s\n", filename().c_str(),
-            strerror(errno));
-    return false;
+  if (fstat(fd.fd(), &buf) < 0) {
+    THROWF("couldn't stat file '$0': $1", filename, strerror(errno));
   }
 
   map = static_cast<char*>(
-      mmap(nullptr, buf.st_size, PROT_READ, MAP_SHARED, fd, 0));
+      mmap(nullptr, buf.st_size, PROT_READ, MAP_SHARED, fd.fd(), 0));
 
   if (map == MAP_FAILED) {
-    fprintf(stderr, "bloaty: couldn't mmap file '%s': %s\n", filename().c_str(),
-            strerror(errno));
-    return false;
+    THROWF("couldn't mmap file '$0': $1", filename, strerror(errno));
   }
 
   data_ = string_view(map, buf.st_size);
-  return true;
 }
 
 MmapInputFile::~MmapInputFile() {
-  if (data_.data() != nullptr) {
-    if (munmap(const_cast<char*>(data_.data()), data_.size()) != 0) {
-      fprintf(stderr, "bloaty: error calling munmap(): %s\n", strerror(errno));
-    }
+  if (data_.data() != nullptr &&
+      munmap(const_cast<char*>(data_.data()), data_.size()) != 0) {
+    fprintf(stderr, "bloaty: error calling munmap(): %s\n", strerror(errno));
   }
 }
 
-std::unique_ptr<InputFile> MmapInputFileFactory::TryOpenFile(
+std::unique_ptr<InputFile> MmapInputFileFactory::OpenFile(
     const std::string& filename) const {
-  std::unique_ptr<MmapInputFile> file(new MmapInputFile(filename));
-  if (!file->Open()) {
-    file.reset();
-  }
-  return std::move(file);
+  return std::unique_ptr<MmapInputFile>(new MmapInputFile(filename));
 }
 
 
@@ -1390,15 +1392,15 @@ class Bloaty {
  public:
   Bloaty(const InputFileFactory& factory);
 
-  bool AddFilename(const std::string& filename, bool base_file);
+  void AddFilename(const std::string& filename, bool base_file);
 
   ConfiguredDataSource* FindDataSource(const std::string& name) const;
   size_t GetSourceCount() const {
     return sources_.size() + (filename_position_ >= 0 ? 1 : 0);
   }
 
-  bool AddDataSource(const std::string& name);
-  bool ScanAndRollup(RollupOutput* output);
+  void AddDataSource(const std::string& name);
+  void ScanAndRollup(RollupOutput* output);
   void PrintDataSources() const {
     for (const auto& source : all_known_sources_) {
       const auto& definition = source.second;
@@ -1419,7 +1421,7 @@ class Bloaty {
     }
   }
 
-  bool ScanAndRollupFile(const InputFile& file, Rollup* rollup);
+  void ScanAndRollupFile(const InputFile& file, Rollup* rollup);
 
   const InputFileFactory& file_factory_;
   std::map<std::string, DataSourceDefinition> all_known_sources_;
@@ -1436,37 +1438,30 @@ Bloaty::Bloaty(const InputFileFactory& factory)
   MakeAllSourcesMap(data_sources);
 }
 
-bool Bloaty::AddFilename(const std::string& filename, bool is_base) {
-  std::unique_ptr<InputFile> file(file_factory_.TryOpenFile(filename));
-  if (!file.get()) {
-    std::cerr << "bloaty: couldn't open file '" << filename << "'\n";
-    return false;
-  }
+void Bloaty::AddFilename(const std::string& filename, bool is_base) {
+  std::unique_ptr<InputFile> file(file_factory_.OpenFile(filename));
+  assert(file.get());
 
   if (is_base) {
     base_files_.push_back(std::move(file));
   } else {
     input_files_.push_back(std::move(file));
   }
-
-  return true;
 }
 
-bool Bloaty::AddDataSource(const std::string& name) {
+void Bloaty::AddDataSource(const std::string& name) {
   if (name == "inputfiles") {
     filename_position_ = sources_.size() + 1;
-    return true;
+    return;
   }
 
   auto it = all_known_sources_.find(name);
   if (it == all_known_sources_.end()) {
-    std::cerr << "bloaty: no such data source: " << name << "\n";
-    return false;
+    THROWF("no such data source: $0", name);
   }
 
   sources_.emplace_back(it->second);
   sources_by_name_[name] = &sources_.back();
-  return true;
 }
 
 ConfiguredDataSource* Bloaty::FindDataSource(const std::string& name) const {
@@ -1478,7 +1473,7 @@ ConfiguredDataSource* Bloaty::FindDataSource(const std::string& name) const {
   }
 }
 
-bool Bloaty::ScanAndRollupFile(const InputFile& file, Rollup* rollup) {
+void Bloaty::ScanAndRollupFile(const InputFile& file, Rollup* rollup) {
   const std::string& filename = file.filename();
   auto file_handler = TryOpenELFFile(file);
 
@@ -1487,8 +1482,7 @@ bool Bloaty::ScanAndRollupFile(const InputFile& file, Rollup* rollup) {
   }
 
   if (!file_handler.get()) {
-    fprintf(stderr, "bloaty: Unknown file type: %s\n", filename.c_str());
-    return false;
+    THROWF("unknown file type for file '$0'", filename.c_str());
   }
 
   struct Maps {
@@ -1505,21 +1499,19 @@ bool Bloaty::ScanAndRollupFile(const InputFile& file, Rollup* rollup) {
       file_maps_.push_back(map->file_map());
     }
 
-    bool ComputeRollup(const std::string& filename, int filename_position,
+    void ComputeRollup(const std::string& filename, int filename_position,
                        Rollup* rollup) {
-      CHECK_RETURN(RangeMap::ComputeRollup(
-          vm_maps_, filename, filename_position,
-          [=](const std::vector<std::string>& keys, uint64_t addr,
-              uint64_t end) {
-            return rollup->AddSizes(keys, end - addr, true);
-          }));
-      CHECK_RETURN(RangeMap::ComputeRollup(
-          file_maps_, filename, filename_position,
-          [=](const std::vector<std::string>& keys, uint64_t addr,
-              uint64_t end) {
-            return rollup->AddSizes(keys, end - addr, false);
-          }));
-      return true;
+      RangeMap::ComputeRollup(vm_maps_, filename, filename_position,
+                              [=](const std::vector<std::string>& keys,
+                                  uint64_t addr, uint64_t end) {
+                                return rollup->AddSizes(keys, end - addr, true);
+                              });
+      RangeMap::ComputeRollup(file_maps_, filename, filename_position,
+                              [=](const std::vector<std::string>& keys,
+                                  uint64_t addr, uint64_t end) {
+                                return rollup->AddSizes(keys, end - addr,
+                                                        false);
+                              });
     }
 
     void PrintMaps(const std::vector<const RangeMap*> maps,
@@ -1533,7 +1525,6 @@ bool Bloaty::ScanAndRollupFile(const InputFile& file, Rollup* rollup) {
                                 }
                                 PrintMapRow(KeysToString(keys), addr, end);
                                 last = end;
-                                return true;
                               });
     }
 
@@ -1589,44 +1580,40 @@ bool Bloaty::ScanAndRollupFile(const InputFile& file, Rollup* rollup) {
     sink_ptrs.push_back(sinks.back().get());
   }
 
-  CHECK_RETURN(file_handler->ProcessFile(sink_ptrs));
+  file_handler->ProcessFile(sink_ptrs);
 
-  CHECK_RETURN(maps.ComputeRollup(filename, filename_position_, rollup));
+  maps.ComputeRollup(filename, filename_position_, rollup);
   if (verbose_level > 0) {
     fprintf(stderr, "FILE MAP:\n");
     maps.PrintFileMaps(filename, filename_position_);
     fprintf(stderr, "VM MAP:\n");
     maps.PrintVMMaps(filename, filename_position_);
   }
-  return true;
 }
 
-bool Bloaty::ScanAndRollup(RollupOutput* output) {
+void Bloaty::ScanAndRollup(RollupOutput* output) {
   if (input_files_.empty()) {
-    fputs("bloaty: no filename specified, exiting.\n", stderr);
-    return false;
+    THROW("no filename specified");
   }
 
   Rollup rollup;
 
   for (const auto& file : input_files_) {
-    CHECK_RETURN(ScanAndRollupFile(*file, &rollup));
+    ScanAndRollupFile(*file, &rollup);
   }
 
   if (!base_files_.empty()) {
     Rollup base;
 
     for (const auto& base_file : base_files_) {
-      CHECK_RETURN(ScanAndRollupFile(*base_file, &base));
+      ScanAndRollupFile(*base_file, &base);
     }
 
     rollup.Subtract(base);
-    CHECK_RETURN(rollup.ComputeWithBase(&base, row_limit_, output));
+    rollup.ComputeWithBase(&base, row_limit_, output);
   } else {
-    CHECK_RETURN(rollup.ComputeWithBase(nullptr, row_limit_, output));
+    rollup.ComputeWithBase(nullptr, row_limit_, output);
   }
-
-  return true;
 }
 
 const char usage[] = R"(Bloaty McBloatface: a size profiler for binaries.
@@ -1656,12 +1643,10 @@ Options:
   --list-sources   Show a list of available sources and exit.
 )";
 
-bool CheckNextArg(int i, int argc, const char *option) {
+void CheckNextArg(int i, int argc, const char *option) {
   if (i + 1 >= argc) {
-    fprintf(stderr, "bloaty: option '%s' requires an argument\n", option);
-    return false;
+    THROWF("option '$0' requires an argument", option);
   }
-  return true;
 }
 
 void Split(const std::string& str, char delim, std::vector<std::string>* out) {
@@ -1672,8 +1657,9 @@ void Split(const std::string& str, char delim, std::vector<std::string>* out) {
   }
 }
 
-bool BloatyMain(int argc, char* argv[], const InputFileFactory& file_factory,
-                RollupOutput* output) {
+static void BloatyDoMain(int argc, char* argv[],
+                         const InputFileFactory& file_factory,
+                         RollupOutput* output) {
   bloaty::Bloaty bloaty(file_factory);
 
   RE2 regex_pattern("(\\w+)\\:s/(.*)/(.*)/");
@@ -1682,49 +1668,41 @@ bool BloatyMain(int argc, char* argv[], const InputFileFactory& file_factory,
   for (int i = 1; i < argc; i++) {
     if (strcmp(argv[i], "--") == 0) {
       if (base_files) {
-        std::cerr << "bloaty: '--' option should only be specified once.\n";
-        return false;
+        THROWF("'--' option should only be specified once");
       }
       base_files = true;
     } else if (strcmp(argv[i], "--csv") == 0) {
       output->SetCSV(true);
     } else if (strcmp(argv[i], "-d") == 0) {
-      if (!CheckNextArg(i, argc, "-d")) {
-        return false;
-      }
+      CheckNextArg(i, argc, "-d");
       std::vector<std::string> names;
       Split(argv[++i], ',', &names);
       for (const auto& name : names) {
-        CHECK_RETURN(bloaty.AddDataSource(name));
+        bloaty.AddDataSource(name);
         output->AddDataSourceName(name);
       }
     } else if (strcmp(argv[i], "-r") == 0) {
+      CheckNextArg(i, argc, "-r");
       std::string source_name, regex, substitution;
       if (!RE2::FullMatch(argv[++i], regex_pattern,
                           &source_name, &regex, &substitution)) {
-        std::cerr << "Bad format for regex, should be: "
-                  << "source+=/pattern/replacement/\n";
-        return false;
+        THROWF(
+            "Bad format for regex, should be: source:s/pattern/replacement/, "
+            "got $0",
+            argv[i]);
       }
 
       auto source = bloaty.FindDataSource(source_name);
       if (!source) {
-        std::cerr << "Data source '" << source_name
-                  << "' not found in previous "
-                  << "-d option\n";
-        return false;
+        THROWF("data source '$0' not found in previous -d option", source_name);
       }
 
       source->munger->AddRegex(regex, substitution);
     } else if (strcmp(argv[i], "-n") == 0) {
-      if (!CheckNextArg(i, argc, "-n")) {
-        return false;
-      }
+      CheckNextArg(i, argc, "-n");
       bloaty.SetRowLimit(strtod(argv[++i], NULL));
     } else if (strcmp(argv[i], "-s") == 0) {
-      if (!CheckNextArg(i, argc, "-s")) {
-        return false;
-      }
+      CheckNextArg(i, argc, "-s");
       i++;
       if (strcmp(argv[i], "vm") == 0) {
         sortby = SortBy::kVM;
@@ -1733,8 +1711,7 @@ bool BloatyMain(int argc, char* argv[], const InputFileFactory& file_factory,
       } else if (strcmp(argv[i], "both") == 0) {
         sortby = SortBy::kBoth;
       } else {
-        std::cerr << "Unknown value for -s: " << argv[i] << "\n";
-        return false;
+        THROWF("unknown value for -s: $0", argv[i]);
       }
     } else if (strcmp(argv[i], "-v") == 0) {
       verbose_level = 1;
@@ -1746,15 +1723,14 @@ bool BloatyMain(int argc, char* argv[], const InputFileFactory& file_factory,
       max_label_len = SIZE_MAX;
     } else if (strcmp(argv[i], "--list-sources") == 0) {
       bloaty.PrintDataSources();
-      return false;
+      return;
     } else if (strcmp(argv[i], "--help") == 0) {
       fputs(usage, stderr);
-      return false;
+      return;
     } else if (argv[i][0] == '-') {
-      std::cerr << "Unknown option: " << argv[i] << "\n";
-      return false;
+      THROWF("Unknown option: $0", argv[i]);
     } else {
-      CHECK_RETURN(bloaty.AddFilename(argv[i], base_files));
+      bloaty.AddFilename(argv[i], base_files);
     }
   }
 
@@ -1763,8 +1739,19 @@ bool BloatyMain(int argc, char* argv[], const InputFileFactory& file_factory,
     bloaty.AddDataSource("sections");
   }
 
-  CHECK_RETURN(bloaty.ScanAndRollup(output));
-  return true;
+  bloaty.ScanAndRollup(output);
+}
+
+bool BloatyMain(int argc, char* argv[],
+                         const InputFileFactory& file_factory,
+                         RollupOutput* output) {
+  try {
+    BloatyDoMain(argc, argv, file_factory, output);
+    return true;
+  } catch (const std::exception& e) {
+    fprintf(stderr, "bloaty: %s\n", e.what());
+    return false;
+  }
 }
 
 }  // namespace bloaty

--- a/src/bloaty.h
+++ b/src/bloaty.h
@@ -49,6 +49,16 @@ enum class DataSource {
   kSymbols,
 };
 
+class Error : public std::runtime_error {
+ public:
+  Error(const char* msg, const char* file, int line)
+      : std::runtime_error(msg), file_(file), line_(line) {}
+
+ private:
+  const char *file_;
+  int line_;
+};
+
 class InputFile {
  public:
   InputFile(const std::string& filename) : filename_(filename) {}
@@ -69,14 +79,14 @@ class InputFileFactory {
  public:
   virtual ~InputFileFactory() {}
 
-  // Returns nullptr if the file could not be opened.
-  virtual std::unique_ptr<InputFile> TryOpenFile(
+  // Throws if the file could not be opened.
+  virtual std::unique_ptr<InputFile> OpenFile(
       const std::string& filename) const = 0;
 };
 
 class MmapInputFileFactory : public InputFileFactory {
  public:
-  std::unique_ptr<InputFile> TryOpenFile(
+  std::unique_ptr<InputFile> OpenFile(
       const std::string& filename) const override;
 };
 
@@ -157,11 +167,11 @@ class FileHandler {
  public:
   virtual ~FileHandler() {}
 
-  virtual bool ProcessBaseMap(RangeSink* sink) = 0;
+  virtual void ProcessBaseMap(RangeSink* sink) = 0;
 
   // Process this file, pushing data to |sinks| as appropriate for each data
   // source.
-  virtual bool ProcessFile(const std::vector<RangeSink*>& sinks) = 0;
+  virtual void ProcessFile(const std::vector<RangeSink*>& sinks) = 0;
 };
 
 std::unique_ptr<FileHandler> TryOpenELFFile(const InputFile& file);
@@ -184,9 +194,9 @@ typedef std::map<absl::string_view, std::pair<uint64_t, uint64_t>> SymbolTable;
 
 // Provided by dwarf.cc.  To use these, a module should fill in a dwarf::File
 // and then call these functions.
-bool ReadDWARFCompileUnits(const dwarf::File& file, const SymbolTable& symtab,
+void ReadDWARFCompileUnits(const dwarf::File& file, const SymbolTable& symtab,
                            RangeSink* sink);
-bool ReadDWARFInlines(const dwarf::File& file, RangeSink* sink,
+void ReadDWARFInlines(const dwarf::File& file, RangeSink* sink,
                       bool include_line);
 
 // LineReader //////////////////////////////////////////////////////////////////
@@ -287,7 +297,7 @@ class RangeMap {
   bool Translate(uint64_t addr, uint64_t *translated) const;
 
   template <class Func>
-  static bool ComputeRollup(const std::vector<const RangeMap*>& range_maps,
+  static void ComputeRollup(const std::vector<const RangeMap*>& range_maps,
                             const std::string& filename, int filename_position,
                             Func func);
 

--- a/src/bloaty.h
+++ b/src/bloaty.h
@@ -54,6 +54,9 @@ class Error : public std::runtime_error {
   Error(const char* msg, const char* file, int line)
       : std::runtime_error(msg), file_(file), line_(line) {}
 
+  const char* file() const { return file_; }
+  int line() const { return line_; }
+
  private:
   const char *file_;
   int line_;

--- a/src/bloaty.h
+++ b/src/bloaty.h
@@ -54,11 +54,13 @@ class Error : public std::runtime_error {
   Error(const char* msg, const char* file, int line)
       : std::runtime_error(msg), file_(file), line_(line) {}
 
+  // TODO(haberman): add these to Bloaty's error message when verbose is
+  // enabled.
   const char* file() const { return file_; }
   int line() const { return line_; }
 
  private:
-  const char *file_;
+  const char* file_;
   int line_;
 };
 

--- a/src/dwarf.cc
+++ b/src/dwarf.cc
@@ -24,7 +24,9 @@
 #include <unordered_set>
 #include <vector>
 
+#include "absl/base/attributes.h"
 #include "absl/strings/string_view.h"
+#include "absl/strings/substitute.h"
 #include "bloaty.h"
 #include "dwarf_constants.h"
 #include "re2/re2.h"
@@ -37,15 +39,21 @@ static size_t AlignUpTo(size_t offset, size_t granularity) {
   return (offset + granularity - 1) & ~(granularity - 1);
 }
 
+ABSL_ATTRIBUTE_NORETURN
+static void Throw(const char *str, int line) {
+  throw bloaty::Error(str, __FILE__, line);
+}
+
+#define THROW(msg) Throw(msg, __LINE__)
+#define THROWF(...) Throw(absl::Substitute(__VA_ARGS__).c_str(), __LINE__)
+#define WARN(x) fprintf(stderr, "bloaty: %s\n", x);
+
 namespace bloaty {
 namespace dwarf {
 
 int DivRoundUp(int n, int d) {
   return (n + (d - 1)) / d;
 }
-
-#define CHECK_RETURN(call) if (!(call)) { return false; }
-#define CHECK_RETURN_STRINGPIECE(call) if (!(call)) { return string_view(); }
 
 
 // Low-level Parsing Routines //////////////////////////////////////////////////
@@ -55,45 +63,66 @@ int DivRoundUp(int n, int d) {
 // is layered on top of these.
 
 template <class T>
-bool ReadMemcpy(string_view* data, T* val) {
-  CHECK_RETURN(data->size() >= sizeof(T));
-  memcpy(val, data->data(), sizeof(T));
+T ReadMemcpy(string_view* data) {
+  T ret;
+  if (data->size() < sizeof(T)) {
+    THROW("premature EOF reading fixed-length DWARF data");
+  }
+  memcpy(&ret, data->data(), sizeof(T));
   data->remove_prefix(sizeof(T));
-  return true;
+  return ret;
 }
 
-bool ReadPiece(size_t bytes, string_view* data, string_view* val) {
-  CHECK_RETURN(data->size() >= bytes);
-  *val = data->substr(0, bytes);
+string_view ReadPiece(size_t bytes, string_view* data) {
+  if(data->size() < bytes) {
+    THROW("premature EOF reading variable-length DWARF data");
+  }
+  string_view ret = data->substr(0, bytes);
   data->remove_prefix(bytes);
-  return true;
+  return ret;
 }
 
-bool SkipBytes(size_t bytes, string_view* data) {
-  CHECK_RETURN(data->size() >= bytes);
+void SkipBytes(size_t bytes, string_view* data) {
+  if (data->size() < bytes) {
+    THROW("premature EOF skipping DWARF data");
+  }
   data->remove_prefix(bytes);
-  return true;
 }
 
-bool ReadNullTerminated(string_view* data, string_view* val) {
+string_view ReadNullTerminated(string_view* data) {
   const char* nullz =
       static_cast<const char*>(memchr(data->data(), '\0', data->size()));
 
   // Return false if not NULL-terminated.
-  CHECK_RETURN(nullz != NULL);
+  if (nullz == NULL) {
+    THROW("DWARF string was not NULL-terminated");
+  }
 
   size_t len = nullz - data->data();
-  *val = data->substr(0, len);
+  string_view val = data->substr(0, len);
   data->remove_prefix(len + 1);  // Remove NULL also.
-  return true;
+  return val;
+}
+
+void SkipNullTerminated(string_view* data) {
+  const char* nullz =
+      static_cast<const char*>(memchr(data->data(), '\0', data->size()));
+
+  // Return false if not NULL-terminated.
+  if (nullz == NULL) {
+    THROW("DWARF string was not NULL-terminated");
+  }
+
+  size_t len = nullz - data->data();
+  data->remove_prefix(len + 1);  // Remove NULL also.
 }
 
 // Parses the LEB128 format defined by DWARF (both signed and unsigned
 // versions).
 
 template <class T>
-typename std::enable_if<std::is_unsigned<T>::value, bool>::type ReadLEB128(
-    string_view* data, T* out) {
+typename std::enable_if<std::is_unsigned<T>::value, T>::type ReadLEB128(
+    string_view* data) {
   uint64_t ret = 0;
   int shift = 0;
   int maxshift = 70;
@@ -106,22 +135,18 @@ typename std::enable_if<std::is_unsigned<T>::value, bool>::type ReadLEB128(
     if ((byte & 0x80) == 0) {
       data->remove_prefix(ptr - data->data());
       if (ret > std::numeric_limits<T>::max()) {
-        fprintf(stderr,
-                "DWARF data contained larger LEB128 than we were expecting.\n");
-        return false;
+        THROW("DWARF data contained larger LEB128 than we were expecting");
       }
-      *out = static_cast<T>(ret);
-      return true;
+      return ret;
     }
   }
 
-  fprintf(stderr, "Corrupt DWARF data, unterminated LEB128.\n");
-  return false;
+  THROW("corrupt DWARF data, unterminated LEB128");
 }
 
 template <class T>
-typename std::enable_if<std::is_signed<T>::value, bool>::type ReadLEB128(
-    string_view* data, T* out) {
+typename std::enable_if<std::is_signed<T>::value, T>::type ReadLEB128(
+    string_view* data) {
   int64_t ret = 0;
   int shift = 0;
   int maxshift = 70;
@@ -139,31 +164,26 @@ typename std::enable_if<std::is_signed<T>::value, bool>::type ReadLEB128(
       }
       if (ret > std::numeric_limits<T>::max() ||
           ret < std::numeric_limits<T>::min()) {
-        fprintf(stderr,
-                "DWARF data contained larger LEB128 than we were expecting.\n");
-        return false;
+        THROW("DWARF data contained larger LEB128 than we were expecting");
       }
-      *out = ret;
-      return true;
+      return ret;
     }
   }
 
-  fprintf(stderr, "Corrupt DWARF data, unterminated LEB128.\n");
-  return false;
+  THROW("corrupt DWARF data, unterminated LEB128");
 }
 
-bool SkipLEB128(string_view* data) {
+void SkipLEB128(string_view* data) {
   size_t limit =
       std::min(static_cast<size_t>(data->size()), static_cast<size_t>(10));
   for (size_t i = 0; i < limit; i++) {
     if (((*data)[i] & 0x80) == 0) {
       data->remove_prefix(i + 1);
-      return true;
+      return;
     }
   }
 
-  fprintf(stderr, "Corrupt DWARF data, unterminated LEB128.\n");
-  return false;
+  THROW("corrupt DWARF data, unterminated LEB128");
 }
 
 // Some size information attached to each compilation unit.  The size of an
@@ -184,30 +204,22 @@ struct CompilationUnitSizes {
 
   // Reads a DWARF offset based on whether we are reading dwarf32 or dwarf64
   // format.
-  bool ReadDWARFOffset(string_view* data, uint64_t* ofs) const {
+  uint64_t ReadDWARFOffset(string_view* data) const {
     if (dwarf64) {
-      return ReadMemcpy(data, ofs);
+      return ReadMemcpy<uint64_t>(data);
     } else {
-      uint32_t ofs32;
-      CHECK_RETURN(ReadMemcpy(data, &ofs32));
-      *ofs = ofs32;
-      return true;
+      return ReadMemcpy<uint32_t>(data);
     }
   }
 
   // Reads an address according to the expected address_size.
-  bool ReadAddress(string_view* data, uint64_t* addr) const {
+  uint64_t ReadAddress(string_view* data) const {
     if (address_size == 8) {
-      return ReadMemcpy(data, addr);
+      return ReadMemcpy<uint64_t>(data);
     } else if (address_size == 4) {
-      uint32_t addr32;
-      CHECK_RETURN(ReadMemcpy(data, &addr32));
-      *addr = addr32;
-      return true;
+      return ReadMemcpy<uint32_t>(data);
     } else {
-      fprintf(stderr, "bloaty: unexpected address size: %d\n",
-              static_cast<int>(address_size));
-      return false;
+      THROWF("unexpected address size: $0", address_size);
     }
   }
 
@@ -215,26 +227,26 @@ struct CompilationUnitSizes {
   // contains either a 32-bit or a 64-bit length, and signals whether we are
   // using the 32-bit or 64-bit DWARF format (so it sets dwarf64 appropriately).
   //
-  // Stores the range for this section in |data| and all of the remaining data
-  // in |next|.
-  bool ReadInitialLength(string_view* data, string_view* next) {
-    uint64_t len;
-    uint32_t len32;
-    CHECK_RETURN(ReadMemcpy(data, &len32));
+  // Returns the range for this section and stores the remaining data
+  // in |remaining|.
+  string_view ReadInitialLength(string_view* remaining) {
+    uint64_t len = ReadMemcpy<uint32_t>(remaining);
 
-    if (len32 == 0xffffffff) {
+    if (len == 0xffffffff) {
       dwarf64 = true;
-      CHECK_RETURN(ReadMemcpy(data, &len));
+      len = ReadMemcpy<uint64_t>(remaining);
     } else {
       dwarf64 = false;
-      len = len32;
     }
 
-    CHECK_RETURN(data->size() >= len);
+    if (remaining->size() < len) {
+      THROW("short DWARF compilation unit");
+    }
 
-    if (next) *next = data->substr(len);
-    data->remove_suffix(data->size() - len);
-    return true;
+    string_view unit = *remaining;
+    unit.remove_suffix(remaining->size() - len);
+    *remaining = remaining->substr(len);
+    return unit;
   }
 };
 
@@ -253,9 +265,8 @@ struct CompilationUnitSizes {
 
 class AbbrevTable {
  public:
-  // Reads abbreviations until a terminating abbreviation is seen.  Returns
-  // false if there is a parse error or a premature EOF.
-  bool ReadAbbrevs(string_view data);
+  // Reads abbreviations until a terminating abbreviation is seen.
+  void ReadAbbrevs(string_view data);
 
   // In a DWARF abbreviation, each attribute has a name and a form.
   struct Attribute {
@@ -292,27 +303,25 @@ class AbbrevTable {
   std::unordered_map<uint32_t, Abbrev> abbrev_;
 };
 
-bool AbbrevTable::ReadAbbrevs(string_view data) {
+void AbbrevTable::ReadAbbrevs(string_view data) {
   while (true) {
-    uint32_t code;
-    CHECK_RETURN(ReadLEB128(&data, &code));
+    uint32_t code = ReadLEB128<uint32_t>(&data);
 
     if (code == 0) {
-      return true;  // Terminator entry.
+      return;  // Terminator entry.
     }
 
     Abbrev& abbrev = abbrev_[code];
 
     if (abbrev.code) {
-      fprintf(stderr, "bloaty: DWARF data contained duplicate abbrev code.\n");
-      return false;
+      THROW("DWARF data contained duplicate abbrev code");
     }
 
     uint8_t has_child;
 
     abbrev.code = code;
-    CHECK_RETURN(ReadLEB128(&data, &abbrev.tag));
-    CHECK_RETURN(ReadMemcpy(&data, &has_child));
+    abbrev.tag = ReadLEB128<uint16_t>(&data);
+    has_child = ReadMemcpy<uint8_t>(&data);
 
     switch (has_child) {
       case DW_children_yes:
@@ -322,13 +331,13 @@ bool AbbrevTable::ReadAbbrevs(string_view data) {
         abbrev.has_child = false;
         break;
       default:
-        return false;
+        THROW("DWARF has_child is neither true nor false.");
     }
 
     while (true) {
       Attribute attr;
-      CHECK_RETURN(ReadLEB128(&data, &attr.name));
-      CHECK_RETURN(ReadLEB128(&data, &attr.form));
+      attr.name = ReadLEB128<uint16_t>(&data);
+      attr.form = ReadLEB128<uint8_t>(&data);
 
       if (attr.name == 0 && attr.form == 0) {
         break;  // End of this abbrev
@@ -352,17 +361,16 @@ class StringTable {
   StringTable(string_view debug_str) : debug_str_(debug_str) {}
 
   // Read a string from the table.
-  bool ReadEntry(size_t ofs, string_view* val) const;
+  string_view ReadEntry(size_t ofs) const;
 
  private:
   string_view debug_str_;
 };
 
-bool StringTable::ReadEntry(size_t ofs, string_view* val) const {
-  CHECK_RETURN(ofs < debug_str_.size());
-  string_view str = debug_str_.substr(ofs);
-  CHECK_RETURN(ReadNullTerminated(&str, val));
-  return true;
+string_view StringTable::ReadEntry(size_t ofs) const {
+  string_view str = debug_str_;
+  SkipBytes(ofs, &str);
+  return ReadNullTerminated(&str);
 }
 
 
@@ -401,41 +409,41 @@ class AddressRanges {
 };
 
 bool AddressRanges::NextRange() {
-  CHECK_RETURN(sizes_.ReadAddress(&unit_remaining_, &address_));
-  CHECK_RETURN(sizes_.ReadAddress(&unit_remaining_, &length_));
+  if (unit_remaining_.empty()) {
+    return false;
+  }
+
+  address_ = sizes_.ReadAddress(&unit_remaining_);
+  length_ = sizes_.ReadAddress(&unit_remaining_);
   return true;
 }
 
 bool AddressRanges::NextUnit() {
-  unit_remaining_ = next_unit_;
-  CHECK_RETURN(sizes_.ReadInitialLength(&unit_remaining_, &next_unit_));
-
-  uint16_t version;
-  CHECK_RETURN(ReadMemcpy(&unit_remaining_, &version));
-
-  if (version > 2) {
-    fprintf(stderr, "bloaty: DWARF data is too new for us.\n");
+  if (next_unit_.empty()) {
     return false;
   }
 
-  CHECK_RETURN(sizes_.ReadDWARFOffset(&unit_remaining_, &debug_info_offset_));
+  unit_remaining_ = sizes_.ReadInitialLength(&next_unit_);
+  uint16_t version = ReadMemcpy<uint16_t>(&unit_remaining_);
+
+  if (version > 2) {
+    THROW("DWARF data is too new for us");
+  }
+
+  debug_info_offset_ = sizes_.ReadDWARFOffset(&unit_remaining_);
 
   uint8_t segment_size;
 
-  CHECK_RETURN(ReadMemcpy(&unit_remaining_, &sizes_.address_size));
-  CHECK_RETURN(ReadMemcpy(&unit_remaining_, &segment_size));
+  sizes_.address_size = ReadMemcpy<uint8_t>(&unit_remaining_);
+  segment_size = ReadMemcpy<uint8_t>(&unit_remaining_);
 
   if (segment_size) {
-    fprintf(stderr,
-            "bloaty: we don't know how to handle segmented addresses.\n");
-    return false;
+    THROW("we don't know how to handle segmented addresses.");
   }
 
   size_t ofs = unit_remaining_.data() - section_.data();
   size_t aligned_ofs = AlignUpTo(ofs, sizes_.address_size * 2);
-  CHECK_RETURN(unit_remaining_.size() >= aligned_ofs - ofs);
-  unit_remaining_.remove_prefix(aligned_ofs - ofs);
-
+  SkipBytes(aligned_ofs - ofs, &unit_remaining_);
   return true;
 }
 
@@ -566,7 +574,6 @@ class DIEReader {
   Section section_;
 
   // Information about the current compilation unit.
-  string_view unit_data_;
   CompilationUnitSizes unit_sizes_;
   AbbrevTable* unit_abbrev_;
 
@@ -586,45 +593,29 @@ class DIEReader {
 
 bool DIEReader::ReadCode() {
   uint32_t code;
-  state_ = State::kError;
-  string_view data = remaining_;
-
-  CHECK_RETURN(ReadLEB128(&data, &code));
-
-  if (code == 0) {
-    remaining_ = data;
-    state_ = State::kEof;
-    return false;
-  } else {
-    CHECK_RETURN(unit_abbrev_->GetAbbrev(code, &current_abbrev_));
-    remaining_ = data;
-    state_ = State::kReadyToReadAttributes;
-    sibling_offset_ = 0;
-    return true;
-  }
-}
-
-bool DIEReader::NextCompilationUnit() {
-  if (next_unit_.size() == 0) {
-    state_ = State::kEof;
-    return false;
-  }
-
-  CHECK_RETURN(ReadCompilationUnitHeader(next_unit_));
-  CHECK_RETURN(ReadCode());
-  return true;
-}
-
-bool DIEReader::NextDIE() {
   do {
-    if (remaining_.size() == 0) {
+    if (remaining_.empty()) {
       state_ = State::kEof;
       return false;
     }
-    ReadCode();
-  } while (state_ == State::kEof);
+    code = ReadLEB128<uint32_t>(&remaining_);
+  } while (code == 0);  // DWARF allows "null entries" for padding.
 
-  return state_ == State::kReadyToReadAttributes;
+  if (!unit_abbrev_->GetAbbrev(code, &current_abbrev_)) {
+    THROW("couldn't find abbreviation for code");
+  }
+  state_ = State::kReadyToReadAttributes;
+  sibling_offset_ = 0;
+  return true;
+}
+
+bool DIEReader::NextCompilationUnit() {
+  return ReadCompilationUnitHeader(next_unit_);
+}
+
+bool DIEReader::NextDIE() {
+  assert(state_ == State::kReadyToNext);
+  return ReadCode();
 }
 
 bool DIEReader::SeekToCompilationUnit(Section section, uint64_t offset) {
@@ -637,55 +628,42 @@ bool DIEReader::SeekToCompilationUnit(Section section, uint64_t offset) {
     data = dwarf_.debug_types;
   }
 
-  CHECK_RETURN(offset < data.size());
-  data.remove_prefix(offset);
-  CHECK_RETURN(ReadCompilationUnitHeader(data));
-  CHECK_RETURN(ReadCode());
-
-  return true;
+  SkipBytes(offset, &data);
+  return ReadCompilationUnitHeader(data);
 }
 
 bool DIEReader::ReadCompilationUnitHeader(string_view data) {
-  if (data.size() == 0) {
+  if (data.empty()) {
     state_ = State::kEof;
     return false;
   }
 
-  string_view unit_data = data;
-  string_view next_unit;
-  unit_sizes_.ReadInitialLength(&data, &next_unit);
+  string_view next_unit_ = data;
+  remaining_ = unit_sizes_.ReadInitialLength(&next_unit_);
 
-  uint16_t version;
-  CHECK_RETURN(ReadMemcpy(&data, &version));
+  uint16_t version = ReadMemcpy<uint16_t>(&remaining_);
 
   if (version > 4) {
-    fprintf(stderr, "Data is in new DWARF format we don't understand.\n");
-    return false;
+    THROW("Data is in new DWARF format we don't understand");
   }
 
-  uint64_t debug_abbrev_offset;
-  CHECK_RETURN(unit_sizes_.ReadDWARFOffset(&data, &debug_abbrev_offset));
+  uint64_t debug_abbrev_offset = unit_sizes_.ReadDWARFOffset(&remaining_);
   unit_abbrev_ = &abbrev_tables_[debug_abbrev_offset];
 
   // If we haven't already read abbreviations for this debug_abbrev_offset, we
   // need to do so now.
   if (unit_abbrev_->IsEmpty()) {
     string_view abbrev_data = dwarf_.debug_abbrev;
-    CHECK_RETURN(abbrev_data.size() >= debug_abbrev_offset);
-    abbrev_data.remove_prefix(debug_abbrev_offset);
-    CHECK_RETURN(unit_abbrev_->ReadAbbrevs(abbrev_data));
+    SkipBytes(debug_abbrev_offset, &abbrev_data);
+    unit_abbrev_->ReadAbbrevs(abbrev_data);
   }
 
-  CHECK_RETURN(ReadMemcpy(&data, &unit_sizes_.address_size));
+  unit_sizes_.address_size = ReadMemcpy<uint8_t>(&remaining_);
 
   if (section_ == Section::kDebugTypes) {
-    CHECK_RETURN(ReadMemcpy(&data, &unit_type_signature_));
-    CHECK_RETURN(unit_sizes_.ReadDWARFOffset(&data, &unit_type_offset_));
+    unit_type_signature_ = ReadMemcpy<uint64_t>(&remaining_);
+    unit_type_offset_ = unit_sizes_.ReadDWARFOffset(&remaining_);
   }
-
-  unit_data_ = unit_data;
-  remaining_ = data;
-  next_unit_ = next_unit;
 
   auto abbrev_id = std::make_pair(unit_abbrev_, unit_sizes_);
   auto insert_pair = abbrev_versions_.insert(
@@ -695,7 +673,7 @@ bool DIEReader::ReadCompilationUnitHeader(string_view data) {
   // was one.
   abbrev_version_ = insert_pair.first->second;
 
-  return true;
+  return ReadCode();
 }
 
 
@@ -715,7 +693,7 @@ bool DIEReader::ReadCompilationUnitHeader(string_view data) {
 
 // The type of the decoding function yielded from all GetFunctionForForm()
 // functions.  The return value indicates the data that remains after we parsed
-// our value out.  If return_value.data() == nullptr, there was an error.
+// our value out.
 typedef string_view FormDecodeFunc(const DIEReader& reader, string_view data,
                                    void* val);
 
@@ -725,7 +703,6 @@ FormDecodeFunc* GetFormDecodeFunc(uint8_t form, CompilationUnitSizes sizes) {
   FormDecodeFunc* func = nullptr;
   FormReader<T>::GetFunctionForForm(sizes, form, [&func](FormDecodeFunc* f) {
     func = f;
-    return true;
   });
   return func;
 }
@@ -745,12 +722,12 @@ class FormReaderBase {
   // Function for parsing a specific, known form.  This function compiles into
   // extremely tight/optimized code for parsing this specific form into one
   // specific C++ type.
-  template <bool (Derived::*mf)()>
+  template <void (Derived::*mf)()>
   static string_view ReadAttr(const DIEReader& reader, string_view data,
                               void* val) {
     Derived form_reader(reader, data,
                         static_cast<typename Derived::type*>(val));
-    if ((form_reader.*mf)() == false) { return string_view(); }
+    (form_reader.*mf)();
     return form_reader.data();
   }
 
@@ -759,15 +736,13 @@ class FormReaderBase {
   // on the form we parse.
   static string_view ReadIndirect(const DIEReader& reader, string_view data,
                                   void* value) {
-    uint16_t form;
-    CHECK_RETURN_STRINGPIECE(ReadLEB128(&data, &form));
-    CHECK_RETURN_STRINGPIECE(form != DW_FORM_indirect);
-    bool ok = Derived::GetFunctionForForm(reader.unit_sizes(), form,
-                                          [&](FormDecodeFunc* func) {
-                                            data = func(reader, data, value);
-                                            return data.data() != nullptr;
-                                          });
-    CHECK_RETURN_STRINGPIECE(ok);
+    uint16_t form = ReadLEB128<uint16_t>(&data);
+    if (form == DW_FORM_indirect) {
+      THROW("indirect attribute has indirect form type");
+    }
+    Derived::GetFunctionForForm(
+        reader.unit_sizes(), form,
+        [&](FormDecodeFunc* func) { data = func(reader, data, value); });
     return data;
   }
 };
@@ -789,38 +764,49 @@ class FormReader<string_view> : public FormReaderBase<FormReader<string_view>> {
       : Base(reader, data), val_(val) {}
 
   template <class Func>
-  static bool GetFunctionForForm(CompilationUnitSizes sizes, uint8_t form,
+  static void GetFunctionForForm(CompilationUnitSizes sizes, uint8_t form,
                                  Func func) {
     switch (form) {
       case DW_FORM_block1:
-        return func(&ReadAttr<&FormReader::ReadBlock<uint8_t>>);
+        func(&ReadAttr<&FormReader::ReadBlock<uint8_t>>);
+        return;
       case DW_FORM_block2:
-        return func(&ReadAttr<&FormReader::ReadBlock<uint16_t>>);
+        func(&ReadAttr<&FormReader::ReadBlock<uint16_t>>);
+        return;
       case DW_FORM_block4:
-        return func(&ReadAttr<&FormReader::ReadBlock<uint32_t>>);
+        func(&ReadAttr<&FormReader::ReadBlock<uint32_t>>);
+        return;
       case DW_FORM_block:
       case DW_FORM_exprloc:
-        return func(&ReadAttr<&FormReader::ReadVariableBlock>);
+        func(&ReadAttr<&FormReader::ReadVariableBlock>);
+        return;
       case DW_FORM_string:
-        return func(&ReadAttr<&FormReader::ReadString>);
+        func(&ReadAttr<&FormReader::ReadString>);
+        return;
       case DW_FORM_strp:
         if (sizes.dwarf64) {
-          return func(&ReadAttr<&FormReader::ReadIndirectString<uint64_t>>);
+          func(&ReadAttr<&FormReader::ReadIndirectString<uint64_t>>);
         } else {
-          return func(&ReadAttr<&FormReader::ReadIndirectString<uint32_t>>);
+          func(&ReadAttr<&FormReader::ReadIndirectString<uint32_t>>);
         }
+        return;
       case DW_FORM_data1:
-        return func(&ReadAttr<&FormReader::ReadFixed<1>>);
+        func(&ReadAttr<&FormReader::ReadFixed<1>>);
+        return;
       case DW_FORM_data2:
-        return func(&ReadAttr<&FormReader::ReadFixed<2>>);
+        func(&ReadAttr<&FormReader::ReadFixed<2>>);
+        return;
       case DW_FORM_data4:
-        return func(&ReadAttr<&FormReader::ReadFixed<4>>);
+        func(&ReadAttr<&FormReader::ReadFixed<4>>);
+        return;
       case DW_FORM_data8:
-        return func(&ReadAttr<&FormReader::ReadFixed<8>>);
+        func(&ReadAttr<&FormReader::ReadFixed<8>>);
+        return;
       case DW_FORM_indirect:
-        return func(&FormReader::ReadIndirect);
+        func(&FormReader::ReadIndirect);
+        return;
       default:
-        return false;
+        THROWF("don't know how to translate form $0 to string_view", form);
     }
   }
 
@@ -828,36 +814,30 @@ class FormReader<string_view> : public FormReaderBase<FormReader<string_view>> {
   string_view* val_;
 
   template <size_t N>
-  bool ReadFixed() {
-    return ReadPiece(N, &data_, val_);
+  void ReadFixed() {
+    *val_ = ReadPiece(N, &data_);
   }
 
   template <class D>
-  bool ReadBlock() {
-    D len;
-    CHECK_RETURN(ReadMemcpy(&data_, &len));
-    CHECK_RETURN(ReadPiece(len, &data_, val_));
-    return true;
+  void ReadBlock() {
+    D len = ReadMemcpy<D>(&data_);
+    *val_ = ReadPiece(len, &data_);
   }
 
-  bool ReadVariableBlock() {
-    uint64_t len;
-    CHECK_RETURN(ReadLEB128(&data_, &len));
-    CHECK_RETURN(ReadPiece(len, &data_, val_));
-    return true;
+  void ReadVariableBlock() {
+    uint64_t len = ReadLEB128<uint64_t>(&data_);
+    *val_ = ReadPiece(len, &data_);
   }
 
-  bool ReadString() {
-    return ReadNullTerminated(&data_, val_);
+  void ReadString() {
+    *val_ = ReadNullTerminated(&data_);
   }
 
   template <class D>
-  bool ReadIndirectString() {
-    D ofs;
+  void ReadIndirectString() {
+    D ofs = ReadMemcpy<D>(&data_);
     StringTable table(reader_.dwarf().debug_str);
-    CHECK_RETURN(ReadMemcpy(&data_, &ofs));
-    CHECK_RETURN(table.ReadEntry(ofs, val_));
-    return true;
+    *val_ = table.ReadEntry(ofs);
   }
 };
 
@@ -877,57 +857,79 @@ class FormReader<T, typename std::enable_if<std::is_integral<T>::value>::type>
       : Base(reader, data), val_(val) {}
 
   template <class Func>
-  static bool GetFunctionForForm(CompilationUnitSizes sizes, uint8_t form,
+  static void GetFunctionForForm(CompilationUnitSizes sizes, uint8_t form,
                                  Func func) {
     switch (form) {
       case DW_FORM_data1:
       case DW_FORM_ref1:
-        return func(&Base::template ReadAttr<&ME::ReadFixed<int8_t>>);
+        func(&Base::template ReadAttr<&ME::ReadFixed<int8_t>>);
+        return;
       case DW_FORM_data2:
       case DW_FORM_ref2:
-        CHECK_RETURN(sizeof(T) >= 2);
-        return func(&Base::template ReadAttr<&ME::ReadFixed<int16_t>>);
+        if (sizeof(T) < 2) {
+          THROW("can't fit data2/ref2 into this type");
+        }
+        func(&Base::template ReadAttr<&ME::ReadFixed<int16_t>>);
+        return;
       case DW_FORM_data4:
       case DW_FORM_ref4:
-        CHECK_RETURN(sizeof(T) >= 4);
-        return func(&Base::template ReadAttr<&ME::ReadFixed<int32_t>>);
+        if (sizeof(T) < 4) {
+          THROW("can't fit data4/ref4 into this type");
+        }
+        func(&Base::template ReadAttr<&ME::ReadFixed<int32_t>>);
+        return;
       case DW_FORM_data8:
       case DW_FORM_ref8:
-        CHECK_RETURN(sizeof(T) >= 8);
-        return func(&Base::template ReadAttr<&ME::ReadFixed<int64_t>>);
+        if (sizeof(T) < 8) {
+          THROW("can't fit data8/ref8 into this type");
+        }
+        func(&Base::template ReadAttr<&ME::ReadFixed<int64_t>>);
+        return;
       case DW_FORM_addr:
         // We require FORM_addr to be parsed into 8 bytes, since there is always
         // the possibility of running into 64-bit files.
-        CHECK_RETURN(sizeof(T) >= 8);
-        CHECK_RETURN(!std::is_signed<T>::value);
-        if (sizes.address_size == 8) {
-          return func(&Base::template ReadAttr<&ME::ReadFixed<int64_t>>);
-        } else if (sizes.address_size == 4) {
-          return func(&Base::template ReadAttr<&ME::ReadFixed<int32_t>>);
-        } else {
-          return false;
+        if (sizeof(T) < 8 || std::is_signed<T>::value) {
+          THROW("can't fit addr into this type");
         }
-        return true;
+        if (sizes.address_size == 8) {
+          func(&Base::template ReadAttr<&ME::ReadFixed<int64_t>>);
+        } else if (sizes.address_size == 4) {
+          func(&Base::template ReadAttr<&ME::ReadFixed<int32_t>>);
+        } else {
+          THROWF("don't know how to handle address size: $0",
+                 sizes.address_size);
+        }
+        return;
+
       case DW_FORM_sec_offset:
         // We require FORM_addr to be parsed into 8 bytes, since there is always
         // the possibility of running into 64-bit files.
-        CHECK_RETURN(sizeof(T) >= 8);
-        CHECK_RETURN(!std::is_signed<T>::value);
-        if (sizes.dwarf64) {
-          return func(&Base::template ReadAttr<&ME::ReadFixed<int64_t>>);
-        } else {
-          return func(&Base::template ReadAttr<&ME::ReadFixed<int32_t>>);
+        if (sizeof(T) < 8 || std::is_signed<T>::value) {
+          THROW("can't fit sec_offset into this type");
         }
+        if (sizes.dwarf64) {
+          func(&Base::template ReadAttr<&ME::ReadFixed<int64_t>>);
+        } else {
+          func(&Base::template ReadAttr<&ME::ReadFixed<int32_t>>);
+        }
+        return;
       case DW_FORM_sdata:
-        CHECK_RETURN(std::is_signed<T>::value);
-        return func(&Base::template ReadAttr<&ME::ReadVariable>);
+        if (!std::is_signed<T>::value) {
+          THROW("sdata must be parsed into signed type");
+        }
+        func(&Base::template ReadAttr<&ME::ReadVariable>);
+        return;
       case DW_FORM_udata:
-        CHECK_RETURN(!std::is_signed<T>::value);
-        return func(&Base::template ReadAttr<&ME::ReadVariable>);
+        if (std::is_signed<T>::value) {
+          THROW("udata must be parsed into unsigned type");
+        }
+        func(&Base::template ReadAttr<&ME::ReadVariable>);
+        return;
       case DW_FORM_indirect:
-        return func(&Base::ReadIndirect);
+        func(&Base::ReadIndirect);
+        return;
       default:
-        return false;
+        THROWF("don't know how to translate form $0 to integer", form);
     }
   }
 
@@ -935,23 +937,19 @@ class FormReader<T, typename std::enable_if<std::is_integral<T>::value>::type>
   T* val_;
 
   template <class U>
-  bool ReadFixed() {
+  void ReadFixed() {
+    U val = ReadMemcpy<U>(&data_);
+    // If the user is reading as signed, then perform sign extension.
+    // TODO(haberman): is this the right behavior?
     if (std::is_signed<T>::value) {
-      // I don't know if this case exists or not in practice.  Do producers ever
-      // ship a data1 that is meant to represent a signed number?
-      typename std::make_signed<U>::type tmp;
-      CHECK_RETURN(ReadMemcpy(&data_, &tmp));
-      *val_ = tmp;
+      *val_ = static_cast<typename std::make_signed<U>::type>(val);
     } else {
-      typename std::make_unsigned<U>::type tmp;
-      CHECK_RETURN(ReadMemcpy(&data_, &tmp));
-      *val_ = tmp;
+      *val_ = static_cast<typename std::make_unsigned<U>::type>(val);
     }
-    return true;
   }
 
-  bool ReadVariable() {
-    return ReadLEB128(&data_, val_);
+  void ReadVariable() {
+    *val_ = ReadLEB128<T>(&data_);
   }
 };
 
@@ -969,33 +967,32 @@ class FormReader<bool> : public FormReaderBase<FormReader<bool>> {
       : Base(reader, data), val_(val) {}
 
   template <class Func>
-  static bool GetFunctionForForm(const DIEReader& /*reader*/, uint8_t form,
+  static void GetFunctionForForm(const DIEReader& /*reader*/, uint8_t form,
                                  Func func) {
     switch (form) {
       case DW_FORM_flag:
-        return func(&Base::template ReadAttr<&FormReader::ReadFlag>);
+        func(&Base::template ReadAttr<&FormReader::ReadFlag>);
+        return;
       case DW_FORM_flag_present:
-        return func(&Base::template ReadAttr<&FormReader::ReadFlagPresent>);
+        func(&Base::template ReadAttr<&FormReader::ReadFlagPresent>);
+        return;
       case DW_FORM_indirect:
-        return func(&ME::ReadIndirect);
+        func(&ME::ReadIndirect);
+        return;
       default:
-        return false;
+        THROWF("don't know how to translate DWARF form $0 into bool", form);
     }
   }
 
  private:
   bool* val_;
 
-  bool ReadFlag() {
-    uint8_t byte;
-    CHECK_RETURN(ReadMemcpy(&data_, &byte));
-    *val_ = byte;
-    return true;
+  void ReadFlag() {
+    *val_ = ReadMemcpy<uint8_t>(&data_);
   }
 
-  bool ReadFlagPresent() {
+  void ReadFlagPresent() {
     *val_ = true;
-    return true;
   }
 };
 
@@ -1012,98 +1009,102 @@ class FormReader<void> : public FormReaderBase<FormReader<void>> {
       : Base(reader, data) {}
 
   template <class Func>
-  static bool GetFunctionForForm(CompilationUnitSizes sizes, uint8_t form,
+  static void GetFunctionForForm(CompilationUnitSizes sizes, uint8_t form,
                                  Func func) {
     switch (form) {
       case DW_FORM_flag_present:
-        return func(&Base::template ReadAttr<&ME::DoNothing>);
+        func(&Base::template ReadAttr<&ME::DoNothing>);
+        return;
       case DW_FORM_data1:
       case DW_FORM_ref1:
       case DW_FORM_flag:
-        return func(&Base::template ReadAttr<&ME::SkipFixed<1>>);
+        func(&Base::template ReadAttr<&ME::SkipFixed<1>>);
+        return;
       case DW_FORM_data2:
       case DW_FORM_ref2:
-        return func(&Base::template ReadAttr<&ME::SkipFixed<2>>);
+        func(&Base::template ReadAttr<&ME::SkipFixed<2>>);
+        return;
       case DW_FORM_data4:
       case DW_FORM_ref4:
-        return func(&Base::template ReadAttr<&ME::SkipFixed<4>>);
+        func(&Base::template ReadAttr<&ME::SkipFixed<4>>);
+        return;
       case DW_FORM_data8:
       case DW_FORM_ref8:
       case DW_FORM_ref_sig8:
-        return func(&Base::template ReadAttr<&ME::SkipFixed<8>>);
+        func(&Base::template ReadAttr<&ME::SkipFixed<8>>);
+        return;
       case DW_FORM_addr:
       case DW_FORM_ref_addr:
         if (sizes.address_size) {
-          return func(&Base::template ReadAttr<&ME::SkipFixed<8>>);
+          func(&Base::template ReadAttr<&ME::SkipFixed<8>>);
         } else if (sizes.address_size == 4) {
-          return func(&Base::template ReadAttr<&ME::SkipFixed<4>>);
+          func(&Base::template ReadAttr<&ME::SkipFixed<4>>);
         } else {
-          return false;
+          THROWF("don't know how to skip address size $0", sizes.address_size);
         }
+        return;
       case DW_FORM_sec_offset:
       case DW_FORM_strp:
         if (sizes.dwarf64) {
-          return func(&Base::template ReadAttr<&ME::SkipFixed<8>>);
+          func(&Base::template ReadAttr<&ME::SkipFixed<8>>);
         } else {
-          return func(&Base::template ReadAttr<&ME::SkipFixed<4>>);
+          func(&Base::template ReadAttr<&ME::SkipFixed<4>>);
         }
+        return;
       case DW_FORM_sdata:
       case DW_FORM_udata:
       case DW_FORM_ref_udata:
-        return func(&Base::template ReadAttr<&ME::SkipVariable>);
-        return true;
+        func(&Base::template ReadAttr<&ME::SkipVariable>);
+        return;
       case DW_FORM_block1:
-        return func(&Base::template ReadAttr<&ME::SkipBlock<uint8_t>>);
-        return true;
+        func(&Base::template ReadAttr<&ME::SkipBlock<uint8_t>>);
+        return;
       case DW_FORM_block2:
-        return func(&Base::template ReadAttr<&ME::SkipBlock<uint16_t>>);
+        func(&Base::template ReadAttr<&ME::SkipBlock<uint16_t>>);
+        return;
       case DW_FORM_block4:
-        return func(&Base::template ReadAttr<&ME::SkipBlock<uint32_t>>);
+        func(&Base::template ReadAttr<&ME::SkipBlock<uint32_t>>);
+        return;
       case DW_FORM_block:
       case DW_FORM_exprloc:
-        return func(&Base::template ReadAttr<&ME::SkipVariableBlock>);
+        func(&Base::template ReadAttr<&ME::SkipVariableBlock>);
+        return;
       case DW_FORM_string:
-        return func(&Base::template ReadAttr<&ME::SkipString>);
+        func(&Base::template ReadAttr<&ME::SkipString>);
+        return;
       case DW_FORM_indirect:
-        return func(&ME::ReadIndirect);
+        func(&ME::ReadIndirect);
+        return;
       default:
-        return false;
+        THROWF("don't know how to skip DWARF form $0", form);
     }
   }
 
  private:
-  bool DoNothing() { return true; }
+  void DoNothing() {}
 
   template <size_t N>
-  bool SkipFixed() {
-    return SkipBytes(N, &data_);
+  void SkipFixed() {
+    SkipBytes(N, &data_);
   }
 
-  bool SkipVariable() {
-    return SkipLEB128(&data_);
+  void SkipVariable() {
+    SkipLEB128(&data_);
   }
 
   template <class D>
-  bool SkipBlock() {
-    D len;
-    CHECK_RETURN(ReadMemcpy(&data_, &len));
-    CHECK_RETURN(SkipBytes(len, &data_));
-    return true;
+  void SkipBlock() {
+    D len = ReadMemcpy<D>(&data_);
+    SkipBytes(len, &data_);
   }
 
-  bool SkipVariableBlock() {
-    uint64_t len;
-    CHECK_RETURN(ReadLEB128(&data_, &len));
-    CHECK_RETURN(SkipBytes(len, &data_));
-    return true;
+  void SkipVariableBlock() {
+    uint64_t len = ReadLEB128<uint64_t>(&data_);
+    SkipBytes(len, &data_);
   }
 
-  bool SkipString() {
-    const char* nullz =
-        static_cast<const char*>(memchr(data_.data(), '\0', data_.size()));
-    CHECK_RETURN(nullz != NULL);  // String must be null terminated.
-    CHECK_RETURN(SkipBytes(nullz - data_.data(), &data_));
-    return true;
+  void SkipString() {
+    SkipNullTerminated(&data_);
   }
 };
 
@@ -1162,9 +1163,7 @@ ActionBuf::ActionBuf(const AbbrevTable::Abbrev& abbrev,
     auto func = GetFormDecodeFunc<void>(attr.form, sizes);
 
     if (!func) {
-      fprintf(stderr, "bloaty: don't know how to skip DWARF form %d\n",
-              attr.form);
-      exit(1);
+      THROWF("don't know how to skip DWARF form $0", attr.form);
     }
 
     action_list_.push_back(AttrAction(func, nullptr, nullptr));
@@ -1175,10 +1174,9 @@ ActionBuf::ActionBuf(const AbbrevTable::Abbrev& abbrev,
     if (action.action.func) {
       assert(action.index < action_list_.size());
       if (action_list_[action.index].data) {
-        fprintf(stderr,
-                "bloaty: internal error, specified same DWARF attribute more "
-                "than once\n");
-        exit(1);
+        THROW(
+            "internal error, specified same DWARF attribute more "
+            "than once");
       }
       action_list_[action.index] = action.action;
     }
@@ -1261,12 +1259,8 @@ class FixedAttrReader {
               std::begin(attributes_));
   }
 
-  // Returns true if the DIE's attributes were successfully parsed and all
-  // expected attributes were present.  The values are available from values().
-  //
-  // If we wanted to allow some parameters to be optional, we could support
-  // having params have an optional<> type.
-  bool ReadAttributes(DIEReader* reader) {
+  // Reads all attributes for this DIE, storing the ones we were expecting.
+  void ReadAttributes(DIEReader* reader) {
     string_view data = reader->ReadAttributesBegin();
 
     // Clear all existing attributes.
@@ -1275,7 +1269,7 @@ class FixedAttrReader {
 
     // Parse all attributes.
     data = GetActionBuf(*reader).ReadAttributes(*reader, data);
-    return reader->ReadAttributesEnd(data, 0);
+    reader->ReadAttributesEnd(data, sibling_);
   }
 
   template <size_t N>
@@ -1403,7 +1397,7 @@ class LineInfoReader {
     uint64_t file_size;
   };
 
-  bool SeekToOffset(uint64_t offset, uint8_t address_size);
+  void SeekToOffset(uint64_t offset, uint8_t address_size);
   bool ReadLineInfo();
   const LineInfo& lineinfo() const { return info_; }
   const FileName& filename(size_t i) const { return filenames_[i]; }
@@ -1448,7 +1442,6 @@ class LineInfoReader {
   std::vector<uint8_t> standard_opcode_lengths_;
   std::vector<std::string> expanded_filenames_;
 
-  string_view program_;
   string_view remaining_;
 
   // Whether we are in a "shadow" part of the bytecode program.  Sometimes parts
@@ -1487,37 +1480,34 @@ class LineInfoReader {
   }
 };
 
-bool LineInfoReader::SeekToOffset(uint64_t offset, uint8_t address_size) {
-  CHECK_RETURN(file_.debug_line.size() > offset);
-  string_view data = file_.debug_line.substr(offset);
-  program_ = data;
+void LineInfoReader::SeekToOffset(uint64_t offset, uint8_t address_size) {
+  string_view data = file_.debug_line;
+  SkipBytes(offset, &data);
 
-  uint16_t version;
-  uint64_t header_length;
   sizes_.address_size = address_size;
-  CHECK_RETURN(sizes_.ReadInitialLength(&data, nullptr));
-  CHECK_RETURN(ReadMemcpy(&data, &version));
-  CHECK_RETURN(sizes_.ReadDWARFOffset(&data, &header_length));
-  CHECK_RETURN(data.size() >= header_length);
+  data = sizes_.ReadInitialLength(&data);
+  uint16_t version = ReadMemcpy<uint16_t>(&data);
+  uint64_t header_length = sizes_.ReadDWARFOffset(&data);
+  string_view program = data;
+  SkipBytes(header_length, &program);
 
-  string_view program = data.substr(header_length);
-
-  CHECK_RETURN(ReadMemcpy(&data, &params_.minimum_instruction_length));
+  params_.minimum_instruction_length = ReadMemcpy<uint8_t>(&data);
   if (version == 4) {
-    CHECK_RETURN(
-        ReadMemcpy(&data, &params_.maximum_operations_per_instruction));
+    params_.maximum_operations_per_instruction = ReadMemcpy<uint8_t>(&data);
   } else {
     params_.maximum_operations_per_instruction = 1;
   }
-  CHECK_RETURN(ReadMemcpy(&data, &params_.default_is_stmt));
-  CHECK_RETURN(ReadMemcpy(&data, &params_.line_base));
-  CHECK_RETURN(ReadMemcpy(&data, &params_.line_range));
-  CHECK_RETURN(ReadMemcpy(&data, &params_.opcode_base));
-  CHECK_RETURN(params_.line_range > 0);
+  params_.default_is_stmt = ReadMemcpy<uint8_t>(&data);
+  params_.line_base = ReadMemcpy<int8_t>(&data);
+  params_.line_range = ReadMemcpy<uint8_t>(&data);
+  params_.opcode_base = ReadMemcpy<uint8_t>(&data);
+  if (params_.line_range == 0) {
+    THROW("line_range of zero will cause divide by zero");
+  }
 
   standard_opcode_lengths_.resize(params_.opcode_base);
   for (size_t i = 1; i < params_.opcode_base; i++) {
-    CHECK_RETURN(ReadMemcpy(&data, &standard_opcode_lengths_[i]));
+    standard_opcode_lengths_[i] = ReadMemcpy<uint8_t>(&data);
   }
 
   // Read include_directories.
@@ -1527,9 +1517,8 @@ bool LineInfoReader::SeekToOffset(uint64_t offset, uint8_t address_size) {
   include_directories_.push_back(string_view());
 
   while (true) {
-    string_view dir;
-    CHECK_RETURN(ReadNullTerminated(&data, &dir));
-    if (dir.size() == 0) {
+    string_view dir = ReadNullTerminated(&data);
+    if (dir.empty()) {
       break;
     }
     include_directories_.push_back(dir);
@@ -1543,20 +1532,24 @@ bool LineInfoReader::SeekToOffset(uint64_t offset, uint8_t address_size) {
   filenames_.push_back(FileName());
   while (true) {
     FileName file_name;
-    CHECK_RETURN(ReadNullTerminated(&data, &file_name.name));
-    if (file_name.name.size() == 0) {
+    file_name.name = ReadNullTerminated(&data);
+    if (file_name.name.empty()) {
       break;
     }
-    CHECK_RETURN(ReadLEB128(&data, &file_name.directory_index));
-    CHECK_RETURN(ReadLEB128(&data, &file_name.modified_time));
-    CHECK_RETURN(ReadLEB128(&data, &file_name.file_size));
+    file_name.directory_index = ReadLEB128<uint32_t>(&data);
+    file_name.modified_time = ReadLEB128<uint64_t>(&data);
+    file_name.file_size = ReadLEB128<uint64_t>(&data);
     filenames_.push_back(file_name);
   }
 
   info_ = LineInfo(params_.default_is_stmt);
   remaining_ = program;
   shadow_ = false;
-  return true;
+
+  for (const auto& name : filenames_) {
+    std::cerr << "filename: " << name.name << "\n";
+  }
+  std::cerr << "Length: " << remaining_.size() << "\n";
 }
 
 bool LineInfoReader::ReadLineInfo() {
@@ -1572,13 +1565,12 @@ bool LineInfoReader::ReadLineInfo() {
   string_view data = remaining_;
 
   while (true) {
-    if (data.size() == 0) {
+    if (data.empty()) {
       remaining_ = data;
       return false;
     }
 
-    uint8_t op;
-    CHECK_RETURN(ReadMemcpy(&data, &op));
+    uint8_t op = ReadMemcpy<uint8_t>(&data);
 
     if (op >= params_.opcode_base) {
       SpecialOpcodeAdvance(op);
@@ -1591,10 +1583,8 @@ bool LineInfoReader::ReadLineInfo() {
     } else {
       switch (op) {
         case DW_LNS_extended_op: {
-          uint16_t len;
-          uint8_t extended_op;
-          CHECK_RETURN(ReadLEB128(&data, &len));
-          CHECK_RETURN(ReadMemcpy(&data, &extended_op));
+          uint16_t len = ReadLEB128<uint16_t>(&data);
+          uint8_t extended_op = ReadMemcpy<uint8_t>(&data);
           switch (extended_op) {
             case DW_LNE_end_sequence: {
               // Preserve address and set end_sequence, but reset everything
@@ -1610,25 +1600,25 @@ bool LineInfoReader::ReadLineInfo() {
               break;
             }
             case DW_LNE_set_address:
-              CHECK_RETURN(sizes_.ReadAddress(&data, &info_.address));
+              info_.address = sizes_.ReadAddress(&data);
               info_.op_index = 0;
               shadow_ = (info_.address == 0);
               break;
             case DW_LNE_define_file: {
               FileName file_name;
-              CHECK_RETURN(ReadNullTerminated(&data, &file_name.name));
-              CHECK_RETURN(ReadLEB128(&data, &file_name.directory_index));
-              CHECK_RETURN(ReadLEB128(&data, &file_name.modified_time));
-              CHECK_RETURN(ReadLEB128(&data, &file_name.file_size));
+              file_name.name = ReadNullTerminated(&data);
+              file_name.directory_index = ReadLEB128<uint32_t>(&data);
+              file_name.modified_time = ReadLEB128<uint64_t>(&data);
+              file_name.file_size = ReadLEB128<uint64_t>(&data);
               filenames_.push_back(file_name);
               break;
             }
             case DW_LNE_set_discriminator:
-              CHECK_RETURN(ReadLEB128(&data, &info_.discriminator));
+              info_.discriminator = ReadLEB128<uint32_t>(&data);
               break;
             default:
               // We don't understand this opcode, skip it.
-              CHECK_RETURN(SkipBytes(len, &data));
+              SkipBytes(len, &data);
               fprintf(stderr,
                       "bloaty: warning: unknown DWARF line table extended "
                       "opcode: %d\n",
@@ -1643,31 +1633,21 @@ bool LineInfoReader::ReadLineInfo() {
             return true;
           }
           break;
-        case DW_LNS_advance_pc: {
-          uint64_t operand;
-          CHECK_RETURN(ReadLEB128(&data, &operand));
-          Advance(operand);
+        case DW_LNS_advance_pc:
+          Advance(ReadLEB128<uint64_t>(&data));
           break;
-        }
-        case DW_LNS_advance_line: {
-          int32_t operand;
-          CHECK_RETURN(ReadLEB128(&data, &operand));
-          info_.line += operand;
+        case DW_LNS_advance_line:
+          info_.line += ReadLEB128<int32_t>(&data);
           break;
-        }
-        case DW_LNS_set_file: {
-          uint32_t operand;
-          CHECK_RETURN(ReadLEB128(&data, &operand));
-          CHECK_RETURN(operand < filenames_.size());
-          info_.file = operand;
+        case DW_LNS_set_file:
+          info_.file = ReadLEB128<uint32_t>(&data);
+          if (info_.file >= filenames_.size()) {
+            THROW("filename index too big");
+          }
           break;
-        }
-        case DW_LNS_set_column: {
-          uint32_t operand;
-          CHECK_RETURN(ReadLEB128(&data, &operand));
-          info_.column = operand;
+        case DW_LNS_set_column:
+          info_.column = ReadLEB128<uint32_t>(&data);
           break;
-        }
         case DW_LNS_negate_stmt:
           info_.is_stmt = !info_.is_stmt;
           break;
@@ -1677,13 +1657,10 @@ bool LineInfoReader::ReadLineInfo() {
         case DW_LNS_const_add_pc:
           SpecialOpcodeAdvance(255);
           break;
-        case DW_LNS_fixed_advance_pc: {
-          uint16_t operand;
-          CHECK_RETURN(ReadMemcpy(&data, &operand));
-          info_.address += operand;
+        case DW_LNS_fixed_advance_pc:
+          info_.address += ReadMemcpy<uint16_t>(&data);
           info_.op_index = 0;
           break;
-        }
         case DW_LNS_set_prologue_end:
           info_.prologue_end = true;
           break;
@@ -1691,11 +1668,11 @@ bool LineInfoReader::ReadLineInfo() {
           info_.epilogue_begin = true;
           break;
         case DW_LNS_set_isa:
-          CHECK_RETURN(ReadLEB128(&data, &info_.isa));
+          info_.isa = ReadLEB128<uint8_t>(&data);
           break;
         default:
           // Unknown opcode, but we know its length so can skip it.
-          CHECK_RETURN(SkipBytes(standard_opcode_lengths_[op], &data));
+          SkipBytes(standard_opcode_lengths_[op], &data);
           fprintf(stderr,
                   "bloaty: warning: unknown DWARF line table opcode: %d\n", op);
           break;
@@ -1726,7 +1703,7 @@ static bool ReadDWARFAddressRanges(const dwarf::File& file, RangeSink* sink) {
 
     std::string GetFilename(uint64_t compilation_unit_offset) {
       auto& name = map_[compilation_unit_offset];
-      if (name.size() == 0) {
+      if (name.empty()) {
         name = LookupFilename(compilation_unit_offset);
       }
       return name;
@@ -1737,8 +1714,8 @@ static bool ReadDWARFAddressRanges(const dwarf::File& file, RangeSink* sink) {
       auto section = dwarf::DIEReader::Section::kDebugInfo;
       if (die_reader_.SeekToCompilationUnit(section, compilation_unit_offset) &&
           die_reader_.GetTag() == DW_TAG_compile_unit &&
-          attr_reader_.ReadAttributes(&die_reader_) &&
-          attr_reader_.HasAttribute<0>()) {
+          (attr_reader_.ReadAttributes(&die_reader_),
+           attr_reader_.HasAttribute<0>())) {
         return std::string(attr_reader_.GetAttribute<0>());
       } else {
         return missing_;
@@ -1765,60 +1742,66 @@ static bool ReadDWARFAddressRanges(const dwarf::File& file, RangeSink* sink) {
   return true;
 }
 
+void AddDIE(const std::string& name,
+            const dwarf::FixedAttrReader<string_view, string_view, uint64_t,
+                                         uint64_t>& attr,
+            const SymbolTable& symtab, RangeSink* sink) {
+  uint64_t low_pc = attr.GetAttribute<2>();
+  uint64_t high_pc = attr.GetAttribute<3>();
+
+  if (attr.HasAttribute<2>() && attr.HasAttribute<3>()) {
+    sink->AddVMRangeIgnoreDuplicate(low_pc, high_pc - low_pc, name);
+  }
+
+  if (attr.HasAttribute<1>()) {
+    auto it = symtab.find(attr.GetAttribute<1>());
+    if (it != symtab.end()) {
+      sink->AddVMRangeIgnoreDuplicate(it->second.first, it->second.second,
+                                      name);
+    }
+  }
+}
+
 // The DWARF debug info can help us get compileunits info.  DIEs for compilation
 // units, functions, and global variables often have attributes that will
 // resolve to addresses.
-static bool ReadDWARFDebugInfo(const dwarf::File& file,
+static void ReadDWARFDebugInfo(const dwarf::File& file,
                                const SymbolTable& symtab, RangeSink* sink) {
   dwarf::DIEReader die_reader(file);
   dwarf::FixedAttrReader<string_view, string_view, uint64_t, uint64_t>
       attr_reader(&die_reader, {DW_AT_name, DW_AT_linkage_name, DW_AT_low_pc,
-                                DW_AT_high_pc});
+                                 DW_AT_high_pc});
 
-  CHECK_RETURN(die_reader.SeekToStart(dwarf::DIEReader::Section::kDebugInfo));
+  if (!die_reader.SeekToStart(dwarf::DIEReader::Section::kDebugInfo)) {
+    WARN("debug info is present, but empty");
+    return;
+  }
 
   do {
-    CHECK_RETURN(attr_reader.ReadAttributes(&die_reader));
-    std::string name = std::string(attr_reader.GetAttribute<0>());
-    if (name.empty()) {
-      continue;
+    attr_reader.ReadAttributes(&die_reader);
+    std::string compileunit_name = std::string(attr_reader.GetAttribute<0>());
+    if (!compileunit_name.empty()) {
+      AddDIE(compileunit_name, attr_reader, symtab, sink);
+
+      while (die_reader.NextDIE()) {
+        attr_reader.ReadAttributes(&die_reader);
+        AddDIE(compileunit_name, attr_reader, symtab, sink);
+      }
     }
-
-    do {
-      uint64_t low_pc = attr_reader.GetAttribute<2>();
-      uint64_t high_pc = attr_reader.GetAttribute<3>();
-
-      if (attr_reader.HasAttribute<2>() && attr_reader.HasAttribute<3>()) {
-        sink->AddVMRangeIgnoreDuplicate(low_pc, high_pc - low_pc, name);
-      }
-
-      if (attr_reader.HasAttribute<1>()) {
-        auto it = symtab.find(attr_reader.GetAttribute<1>());
-        if (it != symtab.end()) {
-          sink->AddVMRangeIgnoreDuplicate(it->second.first, it->second.second,
-                                          name);
-        }
-      }
-    } while (die_reader.NextDIE() && attr_reader.ReadAttributes(&die_reader));
   } while (die_reader.NextCompilationUnit());
-
-  return die_reader.IsEof();
 }
 
-bool ReadDWARFCompileUnits(const dwarf::File& file, const SymbolTable& symtab,
+void ReadDWARFCompileUnits(const dwarf::File& file, const SymbolTable& symtab,
                            RangeSink* sink) {
   if (!file.debug_info.size()) {
-    fprintf(stderr, "bloaty: missing debug info\n");
-    return false;
+    THROW("missing debug info");
   }
 
   if (file.debug_aranges.size()) {
-    CHECK_RETURN(ReadDWARFAddressRanges(file, sink));
+    ReadDWARFAddressRanges(file, sink);
   }
 
-  CHECK_RETURN(ReadDWARFDebugInfo(file, symtab, sink));
-
-  return true;
+  ReadDWARFDebugInfo(file, symtab, sink);
 }
 
 static std::string LineInfoKey(const std::string& file, uint32_t line,
@@ -1845,6 +1828,7 @@ static void ReadDWARFStmtList(bool include_line,
             ? last_source
             : LineInfoKey(line_info_reader->GetExpandedFilename(line_info.file),
                           number, include_line);
+    std::cerr << absl::Substitute("line: $0 $1 $2\n", addr, number, name);
     if (!span_startaddr) {
       span_startaddr = addr;
     } else if (line_info.end_sequence ||
@@ -1860,35 +1844,34 @@ static void ReadDWARFStmtList(bool include_line,
   }
 }
 
-bool ReadDWARFInlines(const dwarf::File& file, RangeSink* sink,
+void ReadDWARFInlines(const dwarf::File& file, RangeSink* sink,
                       bool include_line) {
   if (!file.debug_info.size() || !file.debug_line.size()) {
-    fprintf(stderr, "bloaty: missing debug info\n");
-    return false;
+    THROW("no debug info");
   }
 
   dwarf::DIEReader die_reader(file);
   dwarf::LineInfoReader line_info_reader(file);
   dwarf::FixedAttrReader<uint64_t> attr_reader(&die_reader, {DW_AT_stmt_list});
 
-  CHECK_RETURN(die_reader.SeekToStart(dwarf::DIEReader::Section::kDebugInfo));
+  if (!die_reader.SeekToStart(dwarf::DIEReader::Section::kDebugInfo)) {
+    WARN("debug info is present, but empty");
+  }
 
   while (true) {
-    CHECK_RETURN(attr_reader.ReadAttributes(&die_reader));
+    attr_reader.ReadAttributes(&die_reader);
 
     if (attr_reader.HasAttribute<0>()) {
       uint64_t offset = attr_reader.GetAttribute<0>();
-      CHECK_RETURN(line_info_reader.SeekToOffset(
-          offset, die_reader.unit_sizes().address_size));
+      line_info_reader.SeekToOffset(offset,
+                                    die_reader.unit_sizes().address_size);
       ReadDWARFStmtList(include_line, &line_info_reader, sink);
     }
 
     if (!die_reader.NextCompilationUnit()) {
-      return die_reader.IsEof();
+      return;
     }
   }
-
-  return true;
 }
 
 } // namespace bloaty

--- a/tests/fuzz_target.cc
+++ b/tests/fuzz_target.cc
@@ -34,7 +34,7 @@ class StringPieceInputFileFactory : public InputFileFactory {
   StringPieceInputFileFactory(string_view data) : data_(data) {}
  private:
   string_view data_;
-  std::unique_ptr<InputFile> TryOpenFile(
+  std::unique_ptr<InputFile> OpenFile(
       const std::string& /* filename */) const override {
     return std::unique_ptr<InputFile>(new StringPieceInputFile(data_));
   }


### PR DESCRIPTION
All exceptions are caught at the top-level; nothing is passed
to Bloaty callers.