### PR TITLE
Fixed "extends beyond base map" errors.

### DIFF
--- a/src/range_map.h
+++ b/src/range_map.h
@@ -212,8 +212,9 @@ class RangeMap {
 
   template <class T>
   bool TranslateAndTrimRangeWithEntry(T iter, uint64_t addr, uint64_t size,
-                                      uint64_t* out_addr,
-                                      uint64_t* out_size) const;
+                                      uint64_t* trimmed_addr,
+                                      uint64_t* translated_addr,
+                                      uint64_t* trimmed_size) const;
 
   // Finds the entry that contains |addr|.  If no such mapping exists, returns
   // mappings_.end().

--- a/tests/range_map_test.cc
+++ b/tests/range_map_test.cc
@@ -337,7 +337,9 @@ TEST_F(RangeMapTest, Translation2) {
                                             &map3_));
   CheckConsistency();
   AssertMapEquals(map2_, {
-    {20, 35, kNoTranslation, "translate me"}
+    {20, 25, kNoTranslation, "translate me"},
+    {25, 30, kNoTranslation, "translate me"},
+    {30, 35, kNoTranslation, "translate me"}
   });
   AssertMapEquals(map3_, {
     {120, 125, kNoTranslation, "translate me"},


### PR DESCRIPTION
We drop ranges that are not present in the base map now.
But we warn in this case when -v is set.