### PR TITLE
Fixed compile errors on PRIx64 format

### DIFF
--- a/src/bloaty.h
+++ b/src/bloaty.h
@@ -21,6 +21,7 @@
 
 #include <stdlib.h>
 #define __STDC_LIMIT_MACROS
+#define __STDC_FORMAT_MACROS
 #include <stdint.h>
 
 #include <memory>


### PR DESCRIPTION
GCC 4.9.2 complains about `PRIx64`, under RedHat 7u2:

```
bloaty/src/bloaty.cc: In member function 'void bloaty::RangeSink::AddFileRange(const char*, absl::string_view, uint64_t, uint64_t)':
bloaty/src/bloaty.cc:950:44: error: expected ')' before 'PRIx64'
     printf("[%s, %s] AddFileRange(%.*s, %" PRIx64 ", %" PRIx64 ")\n",
                                            ^
bloaty/src/bloaty.cc:952:42: warning: spurious trailing '%' in format [-Wformat=]
            name.data(), fileoff, filesize);
                                          ^
bloaty/src/bloaty.cc:952:42: warning: too many arguments for format [-Wformat-extra-args]
```

This PR would fix these errors.