### PR TITLE
added install targets for bloaty binary and library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,11 @@ add_library(libbloaty
     # One source file, no special build system needed.
     third_party/demumble/third_party/libcxxabi/cxa_demangle.cpp
     )
-  set_target_properties(libbloaty PROPERTIES OUTPUT_NAME bloaty)
+
+  set_target_properties(libbloaty PROPERTIES
+    OUTPUT_NAME bloaty
+    PUBLIC_HEADER src/bloaty.h
+    )
 
 set(LIBBLOATY_LIBS libbloaty libprotoc re2 capstone-static)
 install(TARGETS libbloaty
@@ -112,7 +116,8 @@ install(TARGETS libbloaty
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
-        INCLUDES DESTINATION include)
+        PUBLIC_HEADER DESTINATION include)
+
 
 if(DEFINED ENV{LIB_FUZZING_ENGINE})
   message("LIB_FUZZING_ENGINE set, building fuzz_target instead of Bloaty")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,9 +104,15 @@ add_library(libbloaty
     # One source file, no special build system needed.
     third_party/demumble/third_party/libcxxabi/cxa_demangle.cpp
     )
+  set_target_properties(libbloaty PROPERTIES OUTPUT_NAME bloaty)
 
 set(LIBBLOATY_LIBS libbloaty libprotoc re2 capstone-static)
-
+install(TARGETS libbloaty
+  EXPORT ${PROJECT_NAME}Targets
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        INCLUDES DESTINATION include)
 
 if(DEFINED ENV{LIB_FUZZING_ENGINE})
   message("LIB_FUZZING_ENGINE set, building fuzz_target instead of Bloaty")
@@ -126,7 +132,13 @@ else()
     target_link_libraries(bloaty "${CMAKE_THREAD_LIBS_INIT}")
   endif()
 
-  enable_testing()
+  install(
+    TARGETS bloaty
+    EXPORT ${PROJECT_NAME}Targets
+    RUNTIME DESTINATION bin
+  )
+
+enable_testing()
 
   if(BUILD_TESTING)
     add_subdirectory(third_party/googletest)
@@ -156,3 +168,5 @@ else()
     add_test(NAME fuzz_test COMMAND fuzz_test ${fuzz_corpus} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/testdata/fuzz_corpus)
   endif()
 endif()
+
+install(EXPORT ${PROJECT_NAME}Targets NAMESPACE ${PROJECT_NAME} DESTINATION lib/${PROJECT_NAME})


### PR DESCRIPTION
when `bloaty` is built and I invoke `make install` neither the binary nor the library is put into the folder referenced by `$CMAKE_INSTALL_PREFIX`. this PR adds this feature to the cmake infrastructure. 
I am yet unable to rid the install tree of all the `third_party` dependencies.