### PR TITLE
Add WASM Demangle

### DIFF
--- a/src/webassembly.cc
+++ b/src/webassembly.cc
@@ -314,7 +314,7 @@ void ReadCodeSection(const Section& section, const FuncNames& names,
       std::string name = "func[" + std::to_string(i) + "]";
       sink->AddFileRange("wasm_function", name, func);
     } else {
-      sink->AddFileRange("wasm_function", iter->second, func);
+      sink->AddFileRange("wasm_function", ItaniumDemangle(iter->second, sink->data_source()), func);
     }
   }
 }


### PR DESCRIPTION
Unmangled symbols (created with the emscripten SDK) look like:
`__Z16computeSomethingihPKNSt3__26vectorIfNS_9allocatorIfEEEE`

(note the extra _ in front of __Z)

It appears the mach-o demangling already accounts for this, so we get nice demangled symbols like:
`computeSomething(int, unsigned char, std::__2::vector<float, std::__2::allocator<float> > const*)`
or
`computeSomething()`

I wasn't sure how to go about adding tests because make_test_files.sh doesn't assume an emscripten sdk is installed.  