### PR TITLE
Document dependency on the protobuf compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ This is not an official Google product.
 
 ## Building Bloaty
 
+To build Bloaty from source, the protobuf compiler is needed.
+On Ubuntu/Debian, you can install it with:
+```
+$ sudo apt-get install protobuf-compiler
+```
+
 Bloaty uses CMake to build.  All dependencies are included as Git submodules.
 To build, simply run:
 


### PR DESCRIPTION
I got build failures looking for protoc when trying to build from source, it seems like that's a dependency but is not documented.

Not sure if you want to suggest that people install it using apt-get or some other method, so happy if you accept this PR or go with something else that documents the dependency.

Thanks!