### PR TITLE
fix compile errors

### DIFF
--- a/src/bloaty.h
+++ b/src/bloaty.h
@@ -23,6 +23,7 @@
 #define __STDC_LIMIT_MACROS
 #define __STDC_FORMAT_MACROS
 #include <stdint.h>
+#include <inttypes.h>
 
 #include <memory>
 #include <set>


### PR DESCRIPTION
[ 35%] Building CXX object CMakeFiles/libbloaty.dir/src/bloaty.cc.o
bloaty/src/bloaty.cc: In member function ‘void bloaty::RangeSink::AddFileRange(const char*, absl::string_view, uint64_t, uint64_t)’:
bloaty/src/bloaty.cc:1057:44: error: expected ‘)’ before ‘PRIx64’
     printf("[%s, %s] AddFileRange(%.*s, %" PRIx64 ", %" PRIx64 ")\n",

fix compile errors ( env:  Ubuntu 18.04 LTS)