### PR TITLE
feat(sabsptr): support for DW_EH_PE_sabsptr

### DIFF
--- a/src/dwarf_constants.h
+++ b/src/dwarf_constants.h
@@ -626,6 +626,7 @@ enum PointerEncoding {
   DW_EH_PE_udata2      = 0x02,
   DW_EH_PE_udata4      = 0x03,
   DW_EH_PE_udata8      = 0x04,
+  DW_EH_PE_sabsptr     = 0x08,
   DW_EH_PE_sleb128     = 0x09,
   DW_EH_PE_sdata2      = 0x0A,
   DW_EH_PE_sdata4      = 0x0B,


### PR DESCRIPTION
When I run bloaty against my binary I got "bloaty: Unexpected
eh_frame format value: 8" error.
According documentation libobjc2 I can interpret this value as
signed version of DW_EH_PE_abstr.
After further research I found that this library has strange handling
for such values [2] and it mentions something about GCC extension.

It looks like this value should be returned as is, at least when
current logic tries to translate it by calling TranslateVMToFile,
this calls fails.

When this value is returned as is it looks like I am getting quite
valid output for my binary.

It might fix https://github.com/google/bloaty/issues/141

[1] https://github.com/gnustep/libobjc2/blob/master/dwarf_eh.h#L23
[2] https://github.com/gnustep/libobjc2/blob/master/dwarf_eh.h#L200