### PR TITLE
Fix several issues when using bloaty with large numbers of input files

### DIFF
--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -1402,7 +1402,8 @@ Bloaty::Bloaty(const InputFileFactory& factory, const Options& options)
   AddBuiltInSources(data_sources, options);
 }
 
-std::unique_ptr<ObjectFile> Bloaty::GetObjectFile(const std::string& filename) const {
+std::unique_ptr<ObjectFile> Bloaty::GetObjectFile(
+    const std::string& filename) const {
   std::unique_ptr<InputFile> file(file_factory_.OpenFile(filename));
   auto object_file = TryOpenELFFile(file);
 
@@ -1728,7 +1729,7 @@ void Bloaty::ScanAndRollup(const Options& options, RollupOutput* output) {
   std::vector<std::string> build_ids;
   std::vector<std::string> input_filenames;
   for (const auto& file_info : input_files_) {
-     input_filenames.push_back(file_info.filename_);
+    input_filenames.push_back(file_info.filename_);
   }
   ScanAndRollupFiles(input_filenames, &build_ids, &rollup);
 

--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -1411,7 +1411,7 @@ std::unique_ptr<ObjectFile> Bloaty::GetObjectFile(
     object_file = TryOpenMachOFile(file);
   }
 
-  if (!object_file.get() && allow_web_assembly) {
+  if (!object_file.get()) {
     object_file = TryOpenWebAssemblyFile(file);
   }
 

--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -451,7 +451,7 @@ class Rollup {
     }
   }
 
-  static double Percent(ssize_t part, size_t whole) {
+  static double Percent(int64_t part, int64_t whole) {
     if (whole == 0) {
       if (part == 0) {
         return NAN;
@@ -674,7 +674,7 @@ std::string DoubleStringPrintf(const char *fmt, double d) {
   return std::string(buf);
 }
 
-std::string SiPrint(ssize_t size, bool force_sign) {
+std::string SiPrint(int64_t size, bool force_sign) {
   const char *prefixes[] = {"", "Ki", "Mi", "Gi", "Ti"};
   size_t num_prefixes = 5;
   size_t n = 0;
@@ -687,7 +687,7 @@ std::string SiPrint(ssize_t size, bool force_sign) {
   std::string ret;
 
   if (fabs(size_d) > 100 || n == 0) {
-    ret = std::to_string(static_cast<ssize_t>(size_d)) + prefixes[n];
+    ret = std::to_string(static_cast<int64_t>(size_d)) + prefixes[n];
     if (force_sign && size > 0) {
       ret = "+" + ret;
     }


### PR DESCRIPTION
Fix the following issues, which all arise when using bloaty with large numbers of input files.

1.  Signed integer overflow in a 32-bit build when the total file/VM size exceeds 2GB.
2.  An error about `--debug-file` arguments if there are more input files than threads.
3.  An assertion failure when using `--source-filter` if there are more input files than threads.
4.  Out-of-memory issues.