### PR TITLE
Disable installing Google Test targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,7 @@ else()
     enable_testing()
 
     if(BUILD_TESTING)
+      set(INSTALL_GTEST OFF)
       add_subdirectory(third_party/googletest)
       include_directories(third_party/googletest/googletest/include)
       include_directories(third_party/googletest/googlemock/include)


### PR DESCRIPTION
When CMake was invoked with -DBUILD_TESTING=ON, Google Test targets
were also installed when calling "make install".