### PR TITLE
Fix disabling Google Test target installation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ else()
     enable_testing()
 
     if(BUILD_TESTING)
-      set(INSTALL_GTEST OFF)
+      option(INSTALL_GTEST "" OFF)
       add_subdirectory(third_party/googletest)
       include_directories(third_party/googletest/googletest/include)
       include_directories(third_party/googletest/googlemock/include)


### PR DESCRIPTION
My previous commit didn't work in all cases. Somehow it worked with my
normal CMake installation, but it didn't work when I built it from
Gentoo's build system. This version works with both.