### PR TITLE
address_size should be uint8_t

### DIFF
--- a/src/dwarf.cc
+++ b/src/dwarf.cc
@@ -420,7 +420,7 @@ class AddressRanges {
   // debug_info_offset().  Must call this once before reading the first unit.
   bool NextUnit();
 
-  bool address_size() const { return sizes_.address_size(); }
+  uint8_t address_size() const { return sizes_.address_size(); }
 
  private:
   CompilationUnitSizes sizes_;


### PR DESCRIPTION
My apologies! I've made an error in https://github.com/google/bloaty/pull/211 that also skipped the reviewer's eyes.

Some compilers would squash the value to only 0 or 1, when casting to the boolean, rendering the DWARF tombstone detection ineffective.