### PR TITLE
Fix parsing of archives

### DIFF
--- a/src/elf.cc
+++ b/src/elf.cc
@@ -655,6 +655,7 @@ class ArFile {
 
    private:
     string_view Consume(size_t n) {
+      n = (n % 2 == 0 ? n : n + 1);
       if (remaining_.size() < n) {
         THROW("premature end of file");
       }


### PR DESCRIPTION
ar files require the data to be 2-bytes aligned. Update the Consume
method to read an even number of bytes. The consumption of the header is
unaltered as it is 60 bytes long.

Fixes: #224