### PR TITLE
Add additional DWARF constants (NFC)

### DIFF
--- a/src/dwarf_constants.h
+++ b/src/dwarf_constants.h
@@ -704,5 +704,16 @@ enum RangeListEntry {
   DW_RLE_start_length = 0x07,
 };
 
+enum UnitType {
+  DW_UT_compile = 0x01,
+  DW_UT_type = 0x02,
+  DW_UT_partial = 0x03,
+  DW_UT_skeleton = 0x04,
+  DW_UT_split_compile = 0x05,
+  DW_UT_split_type = 0x06,
+  DW_UT_lo_user = 0x80,
+  DW_UT_hi_user = 0xff,
+};
+
 }  // namespace dwarf2reader
 #endif  // UTIL_DEBUGINFO_DWARF2ENUMS_H__


### PR DESCRIPTION
This introduces the UnitType constants from the DWARF specification.
This is required to process the translation unit debug information which
enables mapping size contributions to a particular translation unit.