### PR TITLE
Perform a minor optimization in `RangeMap::ComputeRollup`

### DIFF
--- a/src/range_map.h
+++ b/src/range_map.h
@@ -268,6 +268,7 @@ void RangeMap::ComputeRollup(const std::vector<const RangeMap*>& range_maps,
     return;
   }
 
+  iters.reserve(range_maps.size());
   for (auto range_map : range_maps) {
     iters.push_back(range_map->mappings_.begin());
   }


### PR DESCRIPTION
Since we know the final length of `iters`, avoid regrowing the vector to
the required length, reserving the size once avoiding the need to grow
it as we copy the contents in.