### PR TITLE
DWARF: remove unnecessary scope and local variable (NFCI)

### DIFF
--- a/src/dwarf.cc
+++ b/src/dwarf.cc
@@ -885,10 +885,8 @@ AttrValue AttrValue::ParseAttr(const DIEReader &reader, uint8_t form,
       return AttrValue(ReadBytes(4, data));
     case DW_FORM_data8:
       return AttrValue(ReadBytes(8, data));
-    case DW_FORM_rnglistx: {
-      auto val = AttrValue(ReadLEB128<uint64_t>(data));
-      return val;
-    }
+    case DW_FORM_rnglistx:
+      return AttrValue(ReadLEB128<uint64_t>(data));
 
     // Bloaty doesn't currently care about any bool or signed data.
     // So we fudge it a bit and just stuff these in a uint64.


### PR DESCRIPTION
This removes a temporary variable and an unnecessary scope.  We compute
the value and simply return it.  There is no need for the extra scope
here.