### PR TITLE
remove extraneous header

### DIFF
--- a/src/re.h
+++ b/src/re.h
@@ -22,7 +22,6 @@
 #endif
 
 #include "absl/base/attributes.h"
-#include "bloaty.h"
 
 namespace bloaty {
 


### PR DESCRIPTION
This causes issues with header modules and is unnecessary.  Remove the
extraneous include.