### PR TITLE
github: add a workflow configuration for CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,63 @@
+name: build
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_request:
+
+jobs:
+  windows:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        arch: ["Win32", "x64", "ARM64"]
+
+    steps:
+      - uses: actions/echeckout@v2
+      - name: configure
+        run: cmake -B build -D CMAKE_BUILD_TYPE=Debug -G "Visual Studio 16 2019" -A ${{ matrix.arch }} -S .
+      - name: build
+        run: cmake --build build --config Debug
+      - name: test
+        run: ctest build
+
+  macOS:
+    runs-on: macos-latest
+
+    strategy:
+      matrix:
+        include:
+          - { cflags: "", cxxflags: "" }
+          - { cflags: "-fmodules", cxxflags: "-fmodules" }
+
+    steps:
+      - uses: actions/echeckout@v2
+      - name: configure
+        run: cmake -B build -D CMAKE_BUILD_TYPE=Debug -D CMAKE_C_FLAGS=${{ matrix.cflags }} -D CMAKE_CXX_FLAGS=${{ matrix.cxxflags }} -S .
+      - name: build
+        run: cmake --build build --config Debug
+      - name: test
+        run: ctest build
+
+  ubuntu:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - { CC: gcc, CXX: g++ }
+          - { CC: clang, CXX: clang++ }
+
+    steps:
+      - uses: actions/echeckout@v2
+      - name: configure
+        run: cmake -B build -D CMAKE_BUILD_TYPE=Debug -S .
+        env:
+          CC: ${{ matrix.CC }}
+          CXX: ${{ matrix.CXX }}
+      - name: build
+        run: cmake --build build --config Debug
+      - name: test
+        run: ctest build


### PR DESCRIPTION
This adds a build configuration for trying out a unified build/CI flow.
The new build workflow builds:
- macOS x64 with and without modules
- Linux x64 with clang and gcc
- Windows x86, x64, ARM64 with VS2019