### PR TITLE
DWARF: address a truncation warning

### DIFF
--- a/src/dwarf.cc
+++ b/src/dwarf.cc
@@ -607,7 +607,7 @@ class DIEReader {
   // both the current abbrev. table and the sizes.
   uint32_t abbrev_version_;
 
-  std::map<std::pair<AbbrevTable*, CompilationUnitSizes>, uint32_t>
+  std::map<std::pair<AbbrevTable*, CompilationUnitSizes>, size_t>
       abbrev_versions_;
 
   // Only for .debug_types


### PR DESCRIPTION
The result of a `size` was being stored into a `std::pair` where the
type was being stored as a `uint32_t`.  However, the result of a `size`
to a STL container is a `size_t`.  This extends the size member to the
proper size, avoiding a warning.