### PR TITLE
correct an assertion for ILP32 targets

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -134,7 +134,7 @@ template <class T> constexpr T ByteSwap(T val) {
 }
 
 template <class T, size_t N = sizeof(T)> T ReadFixed(absl::string_view *data) {
-  static_assert(N <= sizeof(N), "N too big for this data type");
+  static_assert(N <= sizeof(T), "N too big for this data type");
   T val = 0;
   if (data->size() < N) {
     THROW("premature EOF reading fixed-length data");


### PR DESCRIPTION
The assertion was incorrectly written as `N <= sizeof(N)`.  When
building for 64-bit platforms, the `N` would implicitly be 64-bits (the
default width of an integer).  However, on a 32-bit build, `sizeof(N)`
would be 4, with `N` however being 8 in the case of a 64-bit read.  This
assertion is meant to ensure that the data being read fits into the
destination type and should be `N <= sizeof(T)`.  This repairs the
32-bit builds of bloaty.