### PR TITLE
CI: adjust the testing command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: build
         run: cmake --build build --config Debug
       - name: test
-        run: ctest build
+        run: cmake --build build --config Debug --target RUN_TESTS
 
   macOS:
     runs-on: macos-latest
@@ -40,7 +40,7 @@ jobs:
       - name: build
         run: cmake --build build --config Debug
       - name: test
-        run: ctest build
+        run: cmake --build build --config Debug --target test
 
   ubuntu:
     runs-on: ubuntu-latest
@@ -61,4 +61,4 @@ jobs:
       - name: build
         run: cmake --build build --config Debug
       - name: test
-        run: ctest build
+        run: cmake --build build --config Debug --target test


### PR DESCRIPTION
This adjusts the testing command to match the existing Travis CI
invocation of "make test".  Use `cmake` to drive the test target
to allow using a different make program more easily.