### PR TITLE
tests: repair `fuzz_driver` execution on Windows

### DIFF
--- a/tests/fuzz_driver.cc
+++ b/tests/fuzz_driver.cc
@@ -21,7 +21,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 
 int main(int argc, char **argv) {
   for (int i = 1; i < argc; i++) {
-    std::ifstream in(argv[i]);
+    std::ifstream in(argv[i], std::ios_base::in | std::ios_base::binary);
     in.seekg(0, in.end);
     size_t length = in.tellg();
     in.seekg (0, in.beg);


### PR DESCRIPTION
The fuzz_driver used `std::ifstream` with the single parameter
constructor.  This defaults the second parameter to `std::ios_base::in`
which will process the file in text mode.  This works fine for most
platforms as they largely process input as UTF-8.  However, Windows
defaults to UTF-16 and will fail to process the input as a byte stream
resulting in a failure to load the corpus.  Explicitly set the input
mode to `std::ios_base::in | std::ios_base::binary` to ensure that we
can read the input on all the platforms.  This repairs the fuzzing tests
on Windows.