### PR TITLE
build: adjust the policy check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 cmake_policy(SET CMP0048 NEW)
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
+if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW)
 endif()
 project (Bloaty VERSION 1.1)


### PR DESCRIPTION
Adjust the policy check to use the recommended check using the `POLICY`
operator rather than the version check.