### PR TITLE
CI: cleanup the Windows build configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: configure
-        run: cmake -B build -D CMAKE_BUILD_TYPE=Debug -G "Visual Studio 16 2019" -A ${{ matrix.arch }} -S . -D CMAKE_CXX_FLAGS_Debug="/MTd /Zi /Ob0 /Od /RTC1"
+        run: cmake -B build -D CMAKE_BUILD_TYPE=Debug -G "Visual Studio 16 2019" -A ${{ matrix.arch }} -S .
       - name: build
         run: cmake --build build --config Debug
       - name: test


### PR DESCRIPTION
This once again unifies the CMake configuration for all the platforms.
The only difference between the platforms is the generator.