### PR TITLE
CI: build test dependencies in CI for auditable builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,40 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          repository: llvm/llvm-project
+          ref: llvmorg-13.0.0-rc1
+          path: llvm-project
+          fetch-depth: 1
+      - name: Get LLVM Revision
+        id: llvm-revision
+        run: |
+          echo "::set-output name=revision::$(git -C ${{ github.workspace }}/llvm-project rev-parse HEAD)"
+      - uses: actions/cache@v2
+        id: llvm-build
+        with:
+          path: ${{ github.workspace }}/build/llvm-project
+          key: ${{ runner.os }}-${{ matrix.arch }}-${{ steps.llvm-revision.outputs.revision }}
+      - name: configure LLVM
+        if: steps.llvm-build.outputs.cache-hit != 'true'
+        run: cmake -B ${{ github.workspace }}/build/llvm-project -D CMAKE_BUILD_TYPE=Release -G "Visual Studio 16 2019" -S ${{ github.workspace }}/llvm-project/llvm
+      - name: build LLVM tools
+        if: steps.llvm-build.outputs.cache-hit != 'true'
+        run: |
+          cmake --build ${{ github.workspace }}/build/llvm-project --target FileCheck
+          cmake --build ${{ github.workspace }}/build/llvm-project --target yaml2obj
+
+      - uses: actions/checkout@v2
+        with:
+          path: bloaty
       - name: configure
-        run: cmake -B build -D CMAKE_BUILD_TYPE=Debug -G "Visual Studio 16 2019" -A ${{ matrix.arch }} -S .
+        run: cmake -B build/bloaty -D CMAKE_BUILD_TYPE=Debug -G "Visual Studio 16 2019" -A ${{ matrix.arch }} -S ${{ github.workspace }}/bloaty -D FILECHECK_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/FileCheck.exe -D YAML2OBJ_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/yaml2obj.exe -D LIT_EXECUTABLE=${{ github.workspace }}/llvm-project/utils/lit/lit.py
       - name: build
-        run: cmake --build build --config Debug
+        run: cmake --build build/bloaty --config Debug
       - name: test
-        run: cmake --build build --config Debug --target RUN_TESTS
+        run: |
+          cmake --build build/bloaty --config Debug --target RUN_TESTS
+          cmake --build build/bloaty --config Debug --target check-bloaty
 
   macOS:
     runs-on: macos-latest
@@ -35,12 +63,40 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          repository: llvm/llvm-project
+          ref: llvmorg-13.0.0-rc1
+          path: llvm-project
+          fetch-depth: 1
+      - name: Get LLVM Revision
+        id: llvm-revision
+        run: |
+          echo "::set-output name=revision::$(git -C ${{ github.workspace }}/llvm-project rev-parse HEAD)"
+      - uses: actions/cache@v2
+        id: llvm-build
+        with:
+          path: ${{ github.workspace }}/build/llvm-project
+          key: ${{ runner.os }}-${{ steps.llvm-revision.outputs.revision }}
+      - name: configure LLVM
+        if: steps.llvm-build.outputs.cache-hit != 'true'
+        run: cmake -B ${{ github.workspace }}/build/llvm-project -D CMAKE_BUILD_TYPE=Release ${{ github.workspace }}/llvm-project/llvm
+      - name: build LLVM tools
+        if: steps.llvm-build.outputs.cache-hit != 'true'
+        run: |
+          cmake --build ${{ github.workspace }}/build/llvm-project --target FileCheck
+          cmake --build ${{ github.workspace }}/build/llvm-project --target yaml2obj
+
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/bloaty
       - name: configure
-        run: cmake -B build -D CMAKE_BUILD_TYPE=Debug -D CMAKE_C_FLAGS=${{ matrix.cflags }} -D CMAKE_CXX_FLAGS=${{ matrix.cxxflags }} -S .
+        run: cmake -B build/bloaty -D CMAKE_BUILD_TYPE=Debug -D CMAKE_C_FLAGS=${{ matrix.cflags }} -D CMAKE_CXX_FLAGS=${{ matrix.cxxflags }} -S ${{ github.workspace }}/bloaty -D FILECHECK_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/FileCheck -D YAML2OBJ_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/yaml2obj -D LIT_EXECUTABLE=${{ github.workspace }}/llvm-project/utils/lit/lit.py
       - name: build
-        run: cmake --build build --config Debug
+        run: cmake --build build/bloaty --config Debug
       - name: test
-        run: cmake --build build --config Debug --target test
+        run: |
+          cmake --build build/bloaty --config Debug --target test
+          cmake --build build/bloaty --config Debug --target check-bloaty
 
   ubuntu:
     runs-on: ubuntu-latest
@@ -53,12 +109,40 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          repository: llvm/llvm-project
+          ref: llvmorg-13.0.0-rc1
+          path: llvm-project
+          fetch-depth: 1
+      - name: Get LLVM Revision
+        id: llvm-revision
+        run: |
+          echo "::set-output name=revision::$(git -C ${{ github.workspace }}/llvm-project rev-parse HEAD)"
+      - uses: actions/cache@v2
+        id: llvm-build
+        with:
+          path: ${{ github.workspace }}/build/llvm-project
+          key: ${{ runner.os }}-${{ steps.llvm-revision.outputs.revision }}
+      - name: configure LLVM
+        if: steps.llvm-build.outputs.cache-hit != 'true'
+        run: cmake -B ${{ github.workspace }}/build/llvm-project -D CMAKE_BUILD_TYPE=Release ${{ github.workspace }}/llvm-project/llvm
+      - name: build LLVM tools
+        if: steps.llvm-build.outputs.cache-hit != 'true'
+        run: |
+          cmake --build ${{ github.workspace }}/build/llvm-project --target FileCheck
+          cmake --build ${{ github.workspace }}/build/llvm-project --target yaml2obj
+
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/bloaty
       - name: configure
-        run: cmake -B build -D CMAKE_BUILD_TYPE=Debug -S .
+        run: cmake -B build/bloaty -D CMAKE_BUILD_TYPE=Debug -S ${{ github.workspace }}/bloaty -D FILECHECK_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/FileCheck -D YAML2OBJ_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/yaml2obj -D LIT_EXECUTABLE=${{ github.workspace }}/llvm-project/utils/lit/lit.py
         env:
           CC: ${{ matrix.CC }}
           CXX: ${{ matrix.CXX }}
       - name: build
-        run: cmake --build build --config Debug
+        run: cmake --build build/bloaty --config Debug
       - name: test
-        run: cmake --build build --config Debug --target test
+        run: |
+          cmake --build build/bloaty --config Debug --target test
+          cmake --build build/bloaty --config Debug --target check-bloaty

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,14 +37,14 @@ jobs:
       - name: build LLVM tools
         if: steps.llvm-build.outputs.cache-hit != 'true'
         run: |
-          cmake --build ${{ github.workspace }}/build/llvm-project --target FileCheck
-          cmake --build ${{ github.workspace }}/build/llvm-project --target yaml2obj
+          cmake --build ${{ github.workspace }}/build/llvm-project --config Release --target FileCheck
+          cmake --build ${{ github.workspace }}/build/llvm-project --config Release --target yaml2obj
 
       - uses: actions/checkout@v2
         with:
           path: bloaty
       - name: configure
-        run: cmake -B build/bloaty -D CMAKE_BUILD_TYPE=Debug -G "Visual Studio 16 2019" -A ${{ matrix.arch }} -S ${{ github.workspace }}/bloaty -D FILECHECK_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/FileCheck.exe -D YAML2OBJ_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/yaml2obj.exe -D LIT_EXECUTABLE=${{ github.workspace }}/llvm-project/utils/lit/lit.py
+        run: cmake -B build/bloaty -D CMAKE_BUILD_TYPE=Debug -G "Visual Studio 16 2019" -A ${{ matrix.arch }} -S ${{ github.workspace }}/bloaty -D FILECHECK_EXECUTABLE=${{ github.workspace }}/build/llvm-project/Release/bin/FileCheck.exe -D YAML2OBJ_EXECUTABLE=${{ github.workspace }}/build/llvm-project/Release/bin/yaml2obj.exe -D LIT_EXECUTABLE=${{ github.workspace }}/llvm-project/llvm/utils/lit/lit.py
       - name: build
         run: cmake --build build/bloaty --config Debug
       - name: test
@@ -90,7 +90,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/bloaty
       - name: configure
-        run: cmake -B build/bloaty -D CMAKE_BUILD_TYPE=Debug -D CMAKE_C_FLAGS=${{ matrix.cflags }} -D CMAKE_CXX_FLAGS=${{ matrix.cxxflags }} -S ${{ github.workspace }}/bloaty -D FILECHECK_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/FileCheck -D YAML2OBJ_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/yaml2obj -D LIT_EXECUTABLE=${{ github.workspace }}/llvm-project/utils/lit/lit.py
+        run: cmake -B build/bloaty -D CMAKE_BUILD_TYPE=Debug -D CMAKE_C_FLAGS=${{ matrix.cflags }} -D CMAKE_CXX_FLAGS=${{ matrix.cxxflags }} -S ${{ github.workspace }}/bloaty -D FILECHECK_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/FileCheck -D YAML2OBJ_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/yaml2obj -D LIT_EXECUTABLE=${{ github.workspace }}/llvm-project/llvm/utils/lit/lit.py
       - name: build
         run: cmake --build build/bloaty --config Debug
       - name: test
@@ -136,7 +136,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/bloaty
       - name: configure
-        run: cmake -B build/bloaty -D CMAKE_BUILD_TYPE=Debug -S ${{ github.workspace }}/bloaty -D FILECHECK_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/FileCheck -D YAML2OBJ_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/yaml2obj -D LIT_EXECUTABLE=${{ github.workspace }}/llvm-project/utils/lit/lit.py
+        run: cmake -B build/bloaty -D CMAKE_BUILD_TYPE=Debug -S ${{ github.workspace }}/bloaty -D FILECHECK_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/FileCheck -D YAML2OBJ_EXECUTABLE=${{ github.workspace }}/build/llvm-project/bin/yaml2obj -D LIT_EXECUTABLE=${{ github.workspace }}/llvm-project/llvm/utils/lit/lit.py
         env:
           CC: ${{ matrix.CC }}
           CXX: ${{ matrix.CXX }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,13 +338,17 @@ else()
     find_program(LIT_EXECUTABLE NAMES lit lit.py)
     find_program(FILECHECK_EXECUTABLE FileCheck)
     find_program(YAML2OBJ_EXECUTABLE yaml2obj)
-    if(Python_FOUND AND LIT AND FILECHECK AND YAML2OBJ)
+    if(Python_FOUND AND LIT_EXECUTABLE AND FILECHECK_EXECUTABLE AND YAML2OBJ_EXECUTABLE)
       set(BLOATY_SRC_DIR ${PROJECT_SOURCE_DIR})
       set(BLOATY_OBJ_DIR ${PROJECT_BINARY_DIR})
       configure_file(tests/lit.site.cfg.in tests/lit.site.cfg @ONLY)
 
       add_custom_target(check-bloaty
-        COMMAND ${Python_EXECUTABLE} ${LIT_EXECUTABLE} -sv ${PROJECT_BINARY_DIR}/tests
+        COMMAND ${Python_EXECUTABLE} ${LIT_EXECUTABLE} -sv ${PROJECT_BINARY_DIR}/tests --param bloaty=$<TARGET_FILE:bloaty>
+        DEPENDS
+          bloaty
+          ${CMAKE_CURRENT_SOURCE_DIR}/tests/lit.cfg
+          ${CMAKE_CURRENT_BINARY_DIR}/tests/lit.site.cfg
         COMMENT "Running bloaty tests..."
         USES_TERMINAL)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,7 +335,7 @@ else()
     enable_testing()
 
     find_package(Python COMPONENTS Interpreter)
-    find_program(LIT_EXECUTABLE NAMES lit lit.py)
+    find_program(LIT_EXECUTABLE NAMES lit-script.py lit.py lit)
     find_program(FILECHECK_EXECUTABLE FileCheck)
     find_program(YAML2OBJ_EXECUTABLE yaml2obj)
     if(Python_FOUND AND LIT_EXECUTABLE AND FILECHECK_EXECUTABLE AND YAML2OBJ_EXECUTABLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,6 +351,7 @@ else()
           ${CMAKE_CURRENT_BINARY_DIR}/tests/lit.site.cfg
         COMMENT "Running bloaty tests..."
         USES_TERMINAL)
+      set_property(TARGET check-bloaty PROPERTY FOLDER "tests")
     endif()
 
     if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,13 +335,14 @@ else()
     enable_testing()
 
     find_package(Python COMPONENTS Interpreter)
-    if(Python_FOUND)
+    find_program(LIT_EXECUTABLE NAMES lit lit.py)
+    find_program(FILECHECK_EXECUTABLE FileCheck)
+    find_program(YAML2OBJ_EXECUTABLE yaml2obj)
+    if(Python_FOUND AND LIT AND FILECHECK AND YAML2OBJ)
       set(BLOATY_SRC_DIR ${PROJECT_SOURCE_DIR})
       set(BLOATY_OBJ_DIR ${PROJECT_BINARY_DIR})
       configure_file(tests/lit.site.cfg.in tests/lit.site.cfg @ONLY)
 
-      # TODO(abdulras) polish this further and convert this to `add_test` so that
-      # the default test suite run executes the tests.
       add_custom_target(check-bloaty
         COMMAND ${Python_EXECUTABLE} ${LIT_EXECUTABLE} -sv ${PROJECT_BINARY_DIR}/tests
         COMMENT "Running bloaty tests..."

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -29,6 +29,13 @@ if not bloaty_obj_root:
   lit_config.fatal("missing 'bloaty_obj_root' key in the site specific config")
 bloaty_obj_root = os.path.normpath(bloaty_obj_root)
 
+if not lit_config.params.get('bloaty', None):
+  lit_config.fatal("missing parameter 'bloaty'")
+
+lit_config.note('Using bloaty: {}'.format(lit_config.params['bloaty']))
+lit_config.note('Using FileCheck: {}'.format(config.filecheck_path))
+lit_config.note('Using yaml2obj: {}'.format(config.yaml2obj_path))
+
 use_lit_shell = os.environ.get('LIT_USE_INTERNAL_SHELL', kIsWindows)
 if not use_lit_shell:
   config.available_features.add('shell')
@@ -43,4 +50,4 @@ config.test_exec_root = os.path.join(bloaty_obj_root, 'tests')
 
 config.substitutions.append(('%FileCheck', config.filecheck_path))
 config.substitutions.append(('%yaml2obj', config.yaml2obj_path))
-config.substitutions.append(('%bloaty', make_path(config.bloaty_obj_root, 'bloaty')))
+config.substitutions.append(('%bloaty', lit_config.params['bloaty']))


### PR DESCRIPTION
The dependencies should be relatively light and allow us to have an
audit trail for the software.