### PR TITLE
Update lit config / usage to be msvc compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,14 +338,24 @@ else()
     if(Python_FOUND)
       set(BLOATY_SRC_DIR ${PROJECT_SOURCE_DIR})
       set(BLOATY_OBJ_DIR ${PROJECT_BINARY_DIR})
+
+      find_program(BLOATY_LIT_EXECUTABLE lit lit.exe DOC "Specifies where to find the lit tool" REQUIRED)
+      find_program(BLOATY_FILECHECK_EXECUTABLE filecheck FileCheck.exe DOC "Specifies where to find the lit tool" REQUIRED)
+      find_program(BLOATY_YAML2OBJ_EXECUTABLE yaml2obj yaml2obj.exe DOC "Specifies where to find the yaml2obj tool" REQUIRED)
+
       configure_file(tests/lit.site.cfg.in tests/lit.site.cfg @ONLY)
 
       # TODO(abdulras) polish this further and convert this to `add_test` so that
       # the default test suite run executes the tests.
       add_custom_target(check-bloaty
-        COMMAND ${Python_EXECUTABLE} ${LIT_EXECUTABLE} -sv ${PROJECT_BINARY_DIR}/tests
+        COMMAND ${BLOATY_LIT_EXECUTABLE} -sv ${PROJECT_BINARY_DIR}/tests -D "bloaty_binary=$<TARGET_FILE:bloaty>"
         COMMENT "Running bloaty tests..."
-        USES_TERMINAL)
+        USES_TERMINAL
+        SOURCES
+          tests/lit.cfg
+          tests/lit.site.cfg)
+      add_dependencies(check-bloaty bloaty)
+      set_property(TARGET check-bloaty PROPERTY FOLDER "tests")
     endif()
 
     if(BUILD_TESTING)

--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ $ make -j6
 > NOTE: these tests are still experimental and not covered under CI yet.  Please
 > report any issues in running them.
 
-When configuring the project via CMake, a few additional parameters must be
-specified currently:
-- `-DLIT_EXECUTABLE=<PATH>`: specifies where to find the lit tool
-- `-DFILECHECK_EXECUTABLE=<PATH>`: specifies where to find the FileCheck tool
-- `-DYAML2OBJ_EXECUTABLE=<PATH>`: specifies where to find the yaml2obj tool
+CMake will try to find these on your PATH, if they are not available there,
+or you want to specify other defaults, they can be overrided on the command line:
+- `-DBLOATY_LIT_EXECUTABLE=<PATH>`: specifies where to find the lit tool
+- `-DBLOATY_FILECHECK_EXECUTABLE=<PATH>`: specifies where to find the FileCheck tool
+- `-DBLOATY_YAML2OBJ_EXECUTABLE=<PATH>`: specifies where to find the yaml2obj tool
 
 You can install lit via pip:
 ```sh

--- a/tests/lit.cfg
+++ b/tests/lit.cfg
@@ -43,4 +43,4 @@ config.test_exec_root = os.path.join(bloaty_obj_root, 'tests')
 
 config.substitutions.append(('%FileCheck', config.filecheck_path))
 config.substitutions.append(('%yaml2obj', config.yaml2obj_path))
-config.substitutions.append(('%bloaty', make_path(config.bloaty_obj_root, 'bloaty')))
+config.substitutions.append(('%bloaty', lit_config.params['bloaty_binary']))

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -5,8 +5,8 @@ import os
 config.bloaty_src_root = "@BLOATY_SRC_DIR@"
 config.bloaty_obj_root = "@BLOATY_OBJ_DIR@"
 
-config.filecheck_path = "@FILECHECK_EXECUTABLE@"
-config.yaml2obj_path = "@YAML2OBJ_EXECUTABLE@"
+config.filecheck_path = "@BLOATY_FILECHECK_EXECUTABLE@"
+config.yaml2obj_path = "@BLOATY_YAML2OBJ_EXECUTABLE@"
 
 if not config.test_exec_root:
   config.test_exec_root = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
* `lit`, `filecheck` and `yaml2obj` will be auto-detected using find_program now. They can still be configured manually
* Added the `BLOATY_` prefix on the variables to configure the paths
* Added the lit config files to the `SOURCES` of `check-bloaty` so that they show up in the IDE
* Passed the bloaty path as parameter to `lit`, so that it works with Visual Studio's multi-config


@compnerd Can you please verify that it still works for you?
Note, I have updated the variables to include the `BLOATY_` prefix.

--- 

MSVC output when building `check-bloaty`:
```
Build started...
1>------ Build started: Project: check-bloaty, Configuration: Debug x64 ------
1>Running bloaty tests...
1>-- Testing: 6 tests, 6 workers --
1>Testing:  0.. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 80.. 90..
1>
1>Testing Time: 0.43s
1>  Passed: 6
========== Build: 1 succeeded, 0 failed, 9 up-to-date, 0 skipped ==========
```