### PR TITLE
bloaty: correct misuse of `std::log2`

### DIFF
--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -1617,7 +1617,7 @@ struct DualMaps {
   void PrintMaps(const std::vector<const RangeMap*> maps) {
     uint64_t last = 0;
     uint64_t max = maps[0]->GetMaxAddress();
-    int hex_digits = std::ceil(std::log2(max) / 4);
+    int hex_digits = max > 0 ? std::ceil(std::log2(max) / 4) : 0;
     RangeMap::ComputeRollup(maps, [&](const std::vector<std::string>& keys,
                                       uint64_t addr, uint64_t end) {
       if (addr > last) {


### PR DESCRIPTION
If the parameter to `std::log2` is 0, a pole error occur.  If the value
is < 0, a domain error may occur.  Ensure that the value being passed is
always greater than 0.