### PR TITLE
Support DW_FORM_strx3

### DIFF
--- a/src/dwarf/attr.cc
+++ b/src/dwarf/attr.cc
@@ -125,6 +125,8 @@ AttrValue AttrValue::ParseAttr(const CU& cu, uint8_t form, string_view* data) {
       return AttrValue::UnresolvedString(form, ReadFixed<uint8_t>(data));
     case DW_FORM_strx2:
       return AttrValue::UnresolvedString(form, ReadFixed<uint16_t>(data));
+    case DW_FORM_strx3:
+      return AttrValue::UnresolvedString(form, ReadFixed<uint32_t, 3>(data));
     case DW_FORM_strx4:
       return AttrValue::UnresolvedString(form, ReadFixed<uint32_t>(data));
     case DW_FORM_strx:


### PR DESCRIPTION
c.f. http://www.dwarfstd.org/doc/DWARF5.pdf page 218-219, DW_FORM_strx3 implies a 3-byte integer.

I have a few test ELF files that contain `DW_FORM_strx3` but unfortunately their size is in the 50 megabytes. I'm not sure of a better way to test this.