### PR TITLE
[WebAssembly] Add support for data sections

### DIFF
--- a/src/webassembly.cc
+++ b/src/webassembly.cc
@@ -178,24 +178,31 @@ void ParseSections(RangeSink* sink) {
   });
 }
 
-typedef std::unordered_map<int, std::string> FuncNames;
+typedef std::unordered_map<int, std::string> IndexedNames;
 
-void ReadFunctionNames(const Section& section, FuncNames* names,
-                       RangeSink* sink) {
+void ReadNames(const Section& section, IndexedNames* func_names,
+               IndexedNames* dataseg_names, RangeSink* sink) {
   enum class NameType {
     kModule = 0,
     kFunction = 1,
     kLocal = 2,
+    kLabel = 3,
+    kType = 4,
+    kTable = 5,
+    kMemory = 6,
+    kGlobal = 7,
+    kElemSegment = 8,
+    kDataSegment = 9
   };
 
   string_view data = section.contents;
 
   while (!data.empty()) {
-    char type = ReadVarUInt7(&data);
+    NameType type = static_cast<NameType>(ReadVarUInt7(&data));
     uint32_t size = ReadVarUInt32(&data);
     string_view section = ReadPiece(size, &data);
 
-    if (static_cast<NameType>(type) == NameType::kFunction) {
+    if (type == NameType::kFunction || type == NameType::kDataSegment) {
       uint32_t count = ReadVarUInt32(&section);
       for (uint32_t i = 0; i < count; i++) {
         string_view entry = section;
@@ -204,6 +211,7 @@ void ReadFunctionNames(const Section& section, FuncNames* names,
         string_view name = ReadPiece(name_len, &section);
         entry = StrictSubstr(entry, 0, name.data() - entry.data() + name.size());
         sink->AddFileRange("wasm_funcname", name, entry);
+        IndexedNames *names = (type == NameType::kFunction ? func_names : dataseg_names);
         (*names)[index] = std::string(name);
       }
     }
@@ -276,7 +284,7 @@ uint32_t GetNumFunctionImports(const Section& section) {
   return func_count;
 }
 
-void ReadCodeSection(const Section& section, const FuncNames& names,
+void ReadCodeSection(const Section& section, const IndexedNames& names,
                      uint32_t num_imports, RangeSink* sink) {
   string_view data = section.contents;
 
@@ -301,25 +309,65 @@ void ReadCodeSection(const Section& section, const FuncNames& names,
   }
 }
 
+void ReadDataSection(const Section& section, const IndexedNames& names,
+                     RangeSink* sink) {
+  string_view data = section.contents;
+  uint32_t count = ReadVarUInt32(&data);
+
+  for (uint32_t i = 0; i < count; i++) {
+    string_view segment = data;
+    uint8_t mode = ReadFixed<uint8_t>(&data);
+    if (mode > 1) THROW("multi-memory extension isn't supported");
+    if (mode == 0) { // Active segment
+      // We will need to read the init expr.
+      // For the extended const proposal, read instructions until end is reached
+      // Otherwise, just read a constexpr inst (t.const or global.get)
+      // For now, we just need to support passive segments.
+      continue;
+    }
+    // else, a passive segment
+
+    uint32_t segment_size = ReadVarUInt32(&data);
+    uint32_t total_size = segment_size + (data.data() - segment.data());
+
+    segment = StrictSubstr(segment, 0, total_size);
+    data = StrictSubstr(data, segment_size);
+
+    auto iter = names.find(i);
+    if (iter == names.end()) {
+      std::string name = "data[" + std::to_string(i) + "]";
+      sink->AddFileRange("wasm_data", name, segment);
+    } else {
+      if(iter->second ==".data.global3")
+        printf("Adding range %s, %ld\n", iter->second.c_str(), segment.data() - section.contents.data());
+      sink->AddFileRange("wasm_data", iter->second, segment);
+    }
+  }
+}
+
+
 void ParseSymbols(RangeSink* sink) {
   // First pass: read the custom naming section to get function names.
   std::unordered_map<int, std::string> func_names;
+  std::unordered_map<int, std::string> dataseg_names;
   uint32_t num_imports = 0;
 
   ForEachSection(sink->input_file().data(),
-                 [&func_names, sink](const Section& section) {
+                 [&func_names, &dataseg_names, sink](const Section& section) {
                    if (section.name == "name") {
-                     ReadFunctionNames(section, &func_names, sink);
+                     ReadNames(section, &func_names, &dataseg_names, sink);
                    }
                  });
 
   // Second pass: read the function/code sections.
   ForEachSection(sink->input_file().data(),
-                 [&func_names, &num_imports, sink](const Section& section) {
+                 [&func_names, &dataseg_names, &num_imports, sink](const Section& section) {
                    if (section.id == Section::kImport) {
                      num_imports = GetNumFunctionImports(section);
                    } else if (section.id == Section::kCode) {
                      ReadCodeSection(section, func_names, num_imports, sink);
+                   } else if (section.id == Section::kData) {
+                     ReadDataSection(section, dataseg_names, sink);
                    }
                  });
 }

--- a/src/webassembly.cc
+++ b/src/webassembly.cc
@@ -338,8 +338,6 @@ void ReadDataSection(const Section& section, const IndexedNames& names,
       std::string name = "data[" + std::to_string(i) + "]";
       sink->AddFileRange("wasm_data", name, segment);
     } else {
-      if(iter->second ==".data.global3")
-        printf("Adding range %s, %ld\n", iter->second.c_str(), segment.data() - section.contents.data());
       sink->AddFileRange("wasm_data", iter->second, segment);
     }
   }

--- a/tests/wasm/sections.test
+++ b/tests/wasm/sections.test
@@ -1,0 +1,221 @@
+# RUN: %yaml2obj %s -o %t.obj
+# RUN: %bloaty --raw-map %t.obj | %FileCheck %s
+
+--- !WASM
+FileHeader:
+  Version:         0x1
+Sections:
+  - Type:            TYPE
+    Signatures:
+      - Index:           0
+        ParamTypes:      []
+        ReturnTypes:
+          - I32
+      - Index:           1
+        ParamTypes:
+          - I32
+          - I32
+        ReturnTypes:
+          - I32
+  - Type:            IMPORT
+    Imports:
+      - Module:          env
+        Field:           __linear_memory
+        Kind:            MEMORY
+        Memory:
+          Minimum:         0x1
+      - Module:          env
+        Field:           __stack_pointer
+        Kind:            GLOBAL
+        GlobalType:      I32
+        GlobalMutable:   true
+      - Module:          env
+        Field:           __indirect_function_table
+        Kind:            TABLE
+        Table:
+          Index:           0
+          ElemType:        FUNCREF
+          Limits:
+            Minimum:         0x1
+  - Type:            FUNCTION
+    FunctionTypes:   [ 0, 0, 0, 1 ]
+  - Type:            ELEM
+    Segments:
+      - Offset:
+          Opcode:          I32_CONST
+          Value:           1
+        Functions:       [ 0 ]
+  - Type:            DATACOUNT
+    Count:           4
+  - Type:            CODE
+    Relocations:
+      - Type:            R_WASM_MEMORY_ADDR_LEB
+        Index:           1
+        Offset:          0xD
+      - Type:            R_WASM_MEMORY_ADDR_LEB
+        Index:           2
+        Offset:          0x27
+      - Type:            R_WASM_MEMORY_ADDR_LEB
+        Index:           3
+        Offset:          0x3D
+      - Type:            R_WASM_MEMORY_ADDR_LEB
+        Index:           3
+        Offset:          0x55
+      - Type:            R_WASM_MEMORY_ADDR_SLEB
+        Index:           4
+        Offset:          0x5B
+      - Type:            R_WASM_TABLE_INDEX_SLEB
+        Index:           0
+        Offset:          0x6F
+      - Type:            R_WASM_GLOBAL_INDEX_LEB
+        Index:           7
+        Offset:          0x83
+      - Type:            R_WASM_GLOBAL_INDEX_LEB
+        Index:           7
+        Offset:          0x98
+      - Type:            R_WASM_FUNCTION_INDEX_LEB
+        Index:           0
+        Offset:          0xB4
+      - Type:            R_WASM_GLOBAL_INDEX_LEB
+        Index:           7
+        Offset:          0xCC
+      - Type:            R_WASM_FUNCTION_INDEX_LEB
+        Index:           6
+        Offset:          0xDA
+    Functions:
+      - Index:           0
+        Locals:
+          - Type:            I32
+            Count:           13
+        Body:            41002100200028028880808000210141052102200120026A210341002104200428028C808080002105200320056A2106410021072007280280808080002108200820066A21094100210A200A200936028080808000418480808000210B200B210C200C0F0B
+      - Index:           1
+        Locals:
+          - Type:            I32
+            Count:           2
+        Body:            41818080800021002000210120010F0B
+      - Index:           2
+        Locals:
+          - Type:            I32
+            Count:           8
+        Body:            238080808000210041102101200020016B21022002248080808000410021032002200336020C41022104200220043602081080808080001A4103210541102106200220066A2107200724808080800020050F0B
+      - Index:           3
+        Locals:
+          - Type:            I32
+            Count:           1
+        Body:            108280808000210220020F0B
+  - Type:            DATA
+    Segments:
+      - SectionOffset:   6
+        InitFlags:       0
+        Offset:
+          Opcode:          I32_CONST
+          Value:           0
+        Content:         '00000000'
+      - SectionOffset:   15
+        InitFlags:       0
+        Offset:
+          Opcode:          I32_CONST
+          Value:           4
+        Content:         '03000000'
+      - SectionOffset:   24
+        InitFlags:       0
+        Offset:
+          Opcode:          I32_CONST
+          Value:           8
+        Content:         EFBEADDE
+      - SectionOffset:   33
+        InitFlags:       0
+        Offset:
+          Opcode:          I32_CONST
+          Value:           12
+        Content:         '05000000'
+  - Type:            CUSTOM
+    Name:            linking
+    Version:         2
+    SymbolTable:
+      - Index:           0
+        Kind:            FUNCTION
+        Name:            func1
+        Flags:           [  ]
+        Function:        0
+      - Index:           1
+        Kind:            DATA
+        Name:            global3
+        Flags:           [  ]
+        Segment:         2
+        Size:            4
+      - Index:           2
+        Kind:            DATA
+        Name:            global4
+        Flags:           [  ]
+        Segment:         3
+        Size:            4
+      - Index:           3
+        Kind:            DATA
+        Name:            global1
+        Flags:           [  ]
+        Segment:         0
+        Size:            4
+      - Index:           4
+        Kind:            DATA
+        Name:            global2
+        Flags:           [  ]
+        Segment:         1
+        Size:            4
+      - Index:           5
+        Kind:            FUNCTION
+        Name:            func2
+        Flags:           [  ]
+        Function:        1
+      - Index:           6
+        Kind:            FUNCTION
+        Name:            __original_main
+        Flags:           [  ]
+        Function:        2
+      - Index:           7
+        Kind:            GLOBAL
+        Name:            __stack_pointer
+        Flags:           [ UNDEFINED ]
+        Global:          0
+      - Index:           8
+        Kind:            FUNCTION
+        Name:            main
+        Flags:           [  ]
+        Function:        3
+    SegmentInfo:
+      - Index:           0
+        Name:            .bss.global1
+        Alignment:       2
+        Flags:           [  ]
+      - Index:           1
+        Name:            .data.global2
+        Alignment:       2
+        Flags:           [  ]
+      - Index:           2
+        Name:            .data.global3
+        Alignment:       2
+        Flags:           [  ]
+      - Index:           3
+        Name:            .data.global4
+        Alignment:       2
+        Flags:           [  ]
+  - Type:            CUSTOM
+    Name:            producers
+    Tools:
+      - Name:            clang
+        Version:         '14.0.0 (https://github.com/llvm/llvm-project f71c553a30cc52c0b4a6abbaa82ce97c30c13979)'
+...
+
+# CHECK: FILE MAP:
+# CHECK: 000-008           8             [WASM Header]
+# CHECK: 008-015          13             Type
+# CHECK: 015-068          83             Import
+# CHECK: 068-06f           7             Function
+# CHECK: 06f-078           9             Element
+# CHECK: 078-07b           3             DataCount
+# CHECK: 07b-163         232             Code
+# CHECK: 163-18a          39             Data
+# CHECK: 18a-23f         181             linking
+# CHECK: 23f-2b7         120             producers
+# CHECK: 2b7-2f1          58             reloc.CODE
+

--- a/tests/wasm/symbol_test.test
+++ b/tests/wasm/symbol_test.test
@@ -1,0 +1,209 @@
+# RUN: %yaml2obj %s -o %t.obj
+# RUN: %bloaty -d symbols --raw-map %t.obj | %FileCheck %s
+
+--- !WASM
+FileHeader:
+  Version:         0x1
+Sections:
+  - Type:            TYPE
+    Signatures:
+      - Index:           0
+        ParamTypes:      []
+        ReturnTypes:     []
+      - Index:           1
+        ParamTypes:
+          - I32
+        ReturnTypes:     []
+      - Index:           2
+        ParamTypes:      []
+        ReturnTypes:
+          - I32
+      - Index:           3
+        ParamTypes:
+          - I32
+          - I32
+        ReturnTypes:
+          - I32
+  - Type:            FUNCTION
+    FunctionTypes:   [ 0, 1, 0, 2, 2, 2, 3 ]
+  - Type:            TABLE
+    Tables:
+      - Index:           0
+        ElemType:        FUNCREF
+        Limits:
+          Flags:           [ HAS_MAX ]
+          Minimum:         0x2
+          Maximum:         0x2
+  - Type:            MEMORY
+    Memories:
+      - Flags:           [ HAS_MAX, IS_SHARED ]
+        Minimum:         0x2
+        Maximum:         0x2
+  - Type:            GLOBAL
+    Globals:
+      - Index:           0
+        Type:            I32
+        Mutable:         true
+        InitExpr:
+          Opcode:          I32_CONST
+          Value:           66592
+      - Index:           1
+        Type:            I32
+        Mutable:         true
+        InitExpr:
+          Opcode:          I32_CONST
+          Value:           0
+      - Index:           2
+        Type:            I32
+        Mutable:         false
+        InitExpr:
+          Opcode:          I32_CONST
+          Value:           0
+      - Index:           3
+        Type:            I32
+        Mutable:         false
+        InitExpr:
+          Opcode:          I32_CONST
+          Value:           0
+  - Type:            EXPORT
+    Exports:
+      - Name:            memory
+        Kind:            MEMORY
+        Index:           0
+  - Type:            START
+    StartFunction:   2
+  - Type:            ELEM
+    Segments:
+      - Offset:
+          Opcode:          I32_CONST
+          Value:           1
+        Functions:       [ 3 ]
+  - Type:            DATACOUNT
+    Count:           3
+  - Type:            CODE
+    Functions:
+      - Index:           0
+        Locals:          []
+        Body:            0B
+      - Index:           1
+        Locals:          []
+        Body:            0B
+      - Index:           2
+        Locals:          []
+        Body:            02400240024041900841004101FE4802000E020001020B41800841004104FC08000041840841004104FC08010041880841004104FC080200418C0841004104FC0B004190084102FE170200419008417FFE0002001A0C010B4190084101427FFE0102001A0BFC0900FC0901FC09020B
+      - Index:           3
+        Locals:
+          - Type:            I32
+            Count:           13
+        Body:            41002100200028028488808000210141052102200120026A2103410021042004280288888080002105200320056A210641002107200728028C888080002108200820066A21094100210A200A200936028C88808000418088808000210B200B210C200C0F0B
+      - Index:           4
+        Locals:
+          - Type:            I32
+            Count:           2
+        Body:            41818080800021002000210120010F0B
+      - Index:           5
+        Locals:
+          - Type:            I32
+            Count:           8
+        Body:            238080808000210041102101200020016B21022002248080808000410021032002200336020C41022104200220043602081083808080001A4103210541102106200220066A2107200724808080800020050F0B
+      - Index:           6
+        Locals:
+          - Type:            I32
+            Count:           1
+        Body:            108580808000210220020F0B
+  - Type:            DATA
+    Segments:
+      - SectionOffset:   3
+        InitFlags:       1
+        Content:         '03000000'
+      - SectionOffset:   9
+        InitFlags:       1
+        Content:         EFBEADDE
+      - SectionOffset:   15
+        InitFlags:       1
+        Content:         '05000000'
+  - Type:            CUSTOM
+    Name:            name
+    FunctionNames:
+      - Index:           0
+        Name:            __wasm_call_ctors
+      - Index:           1
+        Name:            __wasm_init_tls
+      - Index:           2
+        Name:            __wasm_init_memory
+      - Index:           3
+        Name:            func1
+      - Index:           4
+        Name:            func2
+      - Index:           5
+        Name:            __original_main
+      - Index:           6
+        Name:            main
+    GlobalNames:
+      - Index:           0
+        Name:            __stack_pointer
+      - Index:           1
+        Name:            __tls_base
+      - Index:           2
+        Name:            __tls_size
+      - Index:           3
+        Name:            __tls_align
+    DataSegmentNames:
+      - Index:           0
+        Name:            .data.global2
+      - Index:           1
+        Name:            .data.global3
+      - Index:           2
+        Name:            .data.global4
+  - Type:            CUSTOM
+    Name:            producers
+    Languages:
+      - Name:            C99
+        Version:         ''
+    Tools:
+      - Name:            clang
+        Version:         '14.0.0 (https://github.com/llvm/llvm-project f71c553a30cc52c0b4a6abbaa82ce97c30c13979)'
+  - Type:            CUSTOM
+    Name:            target_features
+    Features:
+      - Prefix:          USED
+        Name:            atomics
+      - Prefix:          USED
+        Name:            bulk-memory
+...
+
+# Check output for function and passive data segments
+
+# Code section
+# CHECK: 06b-06e           3             __wasm_call_ctors
+# CHECK: 06e-071           3             __wasm_init_tls
+# CHECK: 071-0e2         113             __wasm_init_memory
+# CHECK: 0e2-14b         105             func1
+# CHECK: 14b-15f          20             func2
+# CHECK: 15f-1b6          87             __original_main
+# CHECK: 1b6-1c6          16             main
+
+# Data section
+# FIXME: This is wrong, should be the data section header
+# BUG: 1c6-1c9           3             main
+# CHECK: 1c9-1cf           6             .data.global2
+# CHECK: 1cf-1d5           6             .data.global3
+# CHECK: 1d5-1db           6             .data.global4
+
+# Name section
+# FIXME: Name section header and subsection header is 1db-1e6
+# BUG: 1db-1e6          11             .data.global4
+# Function names
+# CHECK: 1e6-1f9          19             __wasm_call_ctors
+# CHECK: 1f9-20a          17             __wasm_init_tls
+# CHECK: 20a-21e          20             __wasm_init_memory
+# CHECK: 21e-225           7             func1
+# CHECK: 225-22c           7             func2
+# CHECK: 22c-23d          17             __original_main
+# FIXME: Subsection headers and global names
+# BUG: 23d-243           6             main
+# BUG: 243-27f          60             [section name]
+# Data names
+# CHECK: 27f-28e          15             .data.global2
+# CHECK: 28e-29d          15             .data.global3
+# CHECK: 29d-2ac          15             .data.global4


### PR DESCRIPTION
Extend the name section parsing to read data segment names.
Parse the data section, and use those names to sink data segments.

Add a lit test for general section parsing, and function and data symbols.
While doing that, I discovered a couple of minor bugs where section headers
were incorrectly attributed. Rather than fix them in this PR, I left
notes in the test file.