### PR TITLE
Provide size report despite not translating VM pointer

### DIFF
--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -1364,7 +1364,8 @@ absl::string_view RangeSink::TranslateVMToFile(uint64_t address) {
   uint64_t translated;
   if (!translator_->vm_map.Translate(address, &translated) ||
       translated > file_->data().size()) {
-    THROW("Can't translate VM pointer to file");
+    THROWF("Can't translate VM pointer ($0) to file", address);
+
   }
   return file_->data().substr(translated);
 }

--- a/src/bloaty.h
+++ b/src/bloaty.h
@@ -203,6 +203,8 @@ public:
   // input_file().data()) to a VM address.
   uint64_t TranslateFileToVM(const char* ptr);
   absl::string_view TranslateVMToFile(uint64_t address);
+  const DualMap* Translator() { return translator_; }
+
 
   // Decompresses zlib-formatted data and returns the decompressed data.
   // Since the decompressed data is not actually part of the file, any

--- a/src/elf.cc
+++ b/src/elf.cc
@@ -906,6 +906,12 @@ static void ReadELFSymbols(const InputFile& file, RangeSink* sink,
               if (verbose_level > 1) {
                 printf("Disassembling function: %s\n", name.data());
               }
+              // TODO(brandonvu) Continue if VM pointer cannot be translated. Issue #315
+              uint64_t unused;
+              if (!sink->Translator()->vm_map.Translate(full_addr, &unused)) {
+                WARN("Can't translate VM pointer ($0) to file", full_addr);
+                continue;
+              }
               infop->text = sink->TranslateVMToFile(full_addr).substr(0, sym.st_size);
               infop->start_address = full_addr;
               DisassembleFindReferences(*infop, sink);


### PR DESCRIPTION
Size reporting for certain binaries are getting a "Can't translate VM pointer" error and as a result, not outputting size reports.