### PR TITLE
build: add a missing dependency on capstone for libbloaty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,9 @@ add_library(libbloaty STATIC
     # One source file, no special build system needed.
     third_party/demumble/third_party/libcxxabi/cxa_demangle.cpp
     )
+target_link_libraries(libbloaty PUBLIC
+  $<$<BOOL:${CAPSTONE_FOUND}>:${CAPSTONE_LIBRARIES}>
+  $<$<NOT:$<BOOL:${CAPSTONE_FOUND}>>:capstone-static>)
 set_property(TARGET libbloaty PROPERTY FOLDER "bloaty")
 
 if(UNIX OR MINGW)
@@ -280,18 +283,12 @@ if(UNIX OR MINGW)
       list(APPEND LIBBLOATY_LIBS re2)
     endif()
   endif()
-  if(CAPSTONE_FOUND)
-    list(APPEND LIBBLOATY_LIBS ${CAPSTONE_LIBRARIES})
-  else()
-    list(APPEND LIBBLOATY_LIBS capstone-static)
-  endif()
   if(ZLIB_FOUND)
     list(APPEND LIBBLOATY_LIBS ZLIB::ZLIB)
   else()
     list(APPEND LIBBLOATY_LIBS zlibstatic)
   endif()
 else()
-  set(LIBBLOATY_LIBS libbloaty libprotoc capstone-static)
   if(BLOATY_ENABLE_RE2)
     list(APPEND LIBBLOATY_LIBS  re2)
   endif()


### PR DESCRIPTION
`libbloaty` depends on capstone (at least in `disassembler.cc`).  Use `target_link_libraries` to indicate that `libbloaty` should link against capstone which will also ensure that we have the proper header search path for the capstone headers and that capstone is a build dependency for `libbloaty`.  This should hopefully avoid a latent build race that was uncovered in #325.