### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: macos-latest
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - { cflags: "", cxxflags: "" }


### PR DESCRIPTION
Disable fail-fast on macOS builds.  We build with and without modules, and a failure with modules does not necessarily indicate a failure in the other build mode.  This should allow us to get more signal out of a single run.