### PR TITLE
Add missing #include needed on GCC13

### DIFF
--- a/tests/fuzz_driver.cc
+++ b/tests/fuzz_driver.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cassert>
+#include <cstdint>
 #include <iostream>
 #include <fstream>
 #include <vector>


### PR DESCRIPTION
Fixes (with GCC 13.0.1):

```
/builddir/build/BUILD/bloaty-1.1/tests/fuzz_driver.cc:20:45: error: 'uint8_t' does not name a type
   20 | extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
      |                                             ^~~~~~~
/builddir/build/BUILD/bloaty-1.1/tests/fuzz_driver.cc:19:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   18 | #include <vector>
  +++ |+#include <cstdint>
   19 |
```