### PR TITLE
Fix incorrect comparison

### DIFF
--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -126,7 +126,7 @@ void CheckedAdd(int64_t* accum, int64_t val) {
   }
 #else
   bool safe = *accum < 0
-                  ? (val >= std::numeric_limits<int64_t>::max() - *accum)
+                  ? (val >= std::numeric_limits<int64_t>::min() - *accum)
                   : (val <= std::numeric_limits<int64_t>::max() - *accum);
   if (!safe) {
     THROW("integer overflow");


### PR DESCRIPTION
The integer overflow comparison was using an incorrect numeric limit for half of the check as noted by comments in issue #208.  It looks like this was a copy/paste error when CheckAdd() was updated to support other types besides integers by bd5630bf5fb1124b2652a9302a98601be9325516.