### PR TITLE
[WebAssembly] Update yaml2obj results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: llvm/llvm-project
-          ref: llvmorg-13.0.0-rc1
+          ref: llvmorg-17.0.0-rc3
           path: llvm-project
           fetch-depth: 1
       - name: Get LLVM Revision
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: llvm/llvm-project
-          ref: llvmorg-13.0.0-rc1
+          ref: llvmorg-17.0.0-rc3
           path: llvm-project
           fetch-depth: 1
       - name: Get LLVM Revision
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: llvm/llvm-project
-          ref: llvmorg-13.0.0-rc1
+          ref: llvmorg-17.0.0-rc3
           path: llvm-project
           fetch-depth: 1
       - name: Get LLVM Revision

--- a/tests/wasm/active_seg.test
+++ b/tests/wasm/active_seg.test
@@ -41,6 +41,6 @@ Sections:
 # Check output for active data segments
 
 # Data section
-# CHECK: 1d-23           6             .data.global2
-# CHECK: 23-29           6             .data.global3
-# CHECK: 29-2f           6             .data.global4
+# CHECK: 29-2f           6             .data.global2
+# CHECK: 2f-35           6             .data.global3
+# CHECK: 35-3b           6             .data.global4

--- a/tests/wasm/sections.test
+++ b/tests/wasm/sections.test
@@ -208,14 +208,13 @@ Sections:
 
 # CHECK: FILE MAP:
 # CHECK: 000-008           8             [WASM Header]
-# CHECK: 008-015          13             Type
-# CHECK: 015-068          83             Import
-# CHECK: 068-06f           7             Function
-# CHECK: 06f-078           9             Element
-# CHECK: 078-07b           3             DataCount
-# CHECK: 07b-163         232             Code
-# CHECK: 163-18a          39             Data
-# CHECK: 18a-23f         181             linking
-# CHECK: 23f-2b7         120             producers
-# CHECK: 2b7-2f1          58             reloc.CODE
-
+# CHECK: 008-019          17             Type
+# CHECK: 019-070          87             Import
+# CHECK: 070-07b          11             Function
+# CHECK: 07b-088          13             Element
+# CHECK: 088-08f           7             DataCount
+# CHECK: 08f-17a         235             Code
+# CHECK: 17a-1a5          43             Data
+# CHECK: 1a5-25d         184             linking
+# CHECK: 25d-2d9         124             producers
+# CHECK: 2d9-313          58             reloc.CODE

--- a/tests/wasm/symbol_test.test
+++ b/tests/wasm/symbol_test.test
@@ -175,35 +175,35 @@ Sections:
 # Check output for function and passive data segments
 
 # Code section
-# CHECK: 06b-06e           3             __wasm_call_ctors
-# CHECK: 06e-071           3             __wasm_init_tls
-# CHECK: 071-0e2         113             __wasm_init_memory
-# CHECK: 0e2-14b         105             func1
-# CHECK: 14b-15f          20             func2
-# CHECK: 15f-1b6          87             __original_main
-# CHECK: 1b6-1c6          16             main
+# CHECK: 092-095           3             __wasm_call_ctors
+# CHECK: 095-098           3             __wasm_init_tls
+# CHECK: 098-109         113             __wasm_init_memory
+# CHECK: 109-172         105             func1
+# CHECK: 172-186          20             func2
+# CHECK: 186-1dd          87             __original_main
+# CHECK: 1dd-1ed          16             main
 
 # Data section
 # FIXME: This is wrong, should be the data section header
-# BUG: 1c6-1c9           3             main
-# CHECK: 1c9-1cf           6             .data.global2
-# CHECK: 1cf-1d5           6             .data.global3
-# CHECK: 1d5-1db           6             .data.global4
+# BUG:   1ed-1f4           7             main
+# CHECK: 1f4-1fa           6             .data.global2
+# CHECK: 1fa-200           6             .data.global3
+# CHECK: 200-206           6             .data.global4
 
 # Name section
-# FIXME: Name section header and subsection header is 1db-1e6
-# BUG: 1db-1e6          11             .data.global4
+# FIXME: Name section header and subsection header is 206-214
+# BUG:   206-214          14             .data.global4
 # Function names
-# CHECK: 1e6-1f9          19             __wasm_call_ctors
-# CHECK: 1f9-20a          17             __wasm_init_tls
-# CHECK: 20a-21e          20             __wasm_init_memory
-# CHECK: 21e-225           7             func1
-# CHECK: 225-22c           7             func2
-# CHECK: 22c-23d          17             __original_main
+# CHECK: 214-227          19             __wasm_call_ctors
+# CHECK: 227-238          17             __wasm_init_tls
+# CHECK: 238-24c          20             __wasm_init_memory
+# CHECK: 24c-253           7             func1
+# CHECK: 253-25a           7             func2
+# CHECK: 25a-26b          17             __original_main
 # FIXME: Subsection headers and global names
-# BUG: 23d-243           6             main
-# BUG: 243-27f          60             [section name]
+# BUG:   26b-271           6             main
+# BUG:   271-2ad          60             [section name]
 # Data names
-# CHECK: 27f-28e          15             .data.global2
-# CHECK: 28e-29d          15             .data.global3
-# CHECK: 29d-2ac          15             .data.global4
+# CHECK: 2ad-2bc          15             .data.global2
+# CHECK: 2bc-2cb          15             .data.global3
+# CHECK: 2cb-2da          15             .data.global4


### PR DESCRIPTION
After
https://github.com/llvm/llvm-project/commit/1b21067cf247c62c2442daa7ee2d3915249d1ee2, if sections in Wasm YAML files don't have `HeaderSecSizeEncodingLen` field specified, yaml2obj will automatically pad header section to 5 bytes, which was a byproduct of fixing some llvm-objcopy issue.

cc @dschuff