### PR TITLE
Fix non-standard parsing of DWARF 5 Type Unit Headers (7.5.3)

### DIFF
--- a/src/dwarf/debug_info.cc
+++ b/src/dwarf/debug_info.cc
@@ -146,9 +146,9 @@ void CU::ReadHeader(string_view entire_unit, string_view data,
     switch (unit_type_) {
       case DW_UT_skeleton:
       case DW_UT_split_compile:
-      case DW_UT_split_type:
         dwo_id_ = ReadFixed<uint64_t>(&data);
         break;
+      case DW_UT_split_type:
       case DW_UT_type:
         unit_type_signature_ = ReadFixed<uint64_t>(&data);
         unit_type_offset_ = unit_sizes_.ReadDWARFOffset(&data);


### PR DESCRIPTION
It appears to me that the current implementation of DWARF 5 Unit Type Header parsing in [CU::ReadHeader](https://github.com/google/bloaty/blob/2757d3ec0fec07f4ac7f2f96fe8f0b020c2d84fb/src/dwarf/debug_info.cc#L146) does not honour the standard.

_Section 7.5.1.3 Type Unit Headers_ reads:
```
3. unit_type (ubyte)
A 1-byte unsigned integer identifying this unit as a type unit. The value of
this field is DW_UT_type for a non-split type unit (see Section 3.1.4 on
page 68) or DW_UT_split_type for a split type unit.
```
The current implementation associates `DW_UT_split_type` with Skeleton and Split Compilation Unit Headers (7.5.1.2), wrongly consuming a `dwo_id` unit ID an missing the `type_signature` and `type_offset` information.