### PR TITLE
Fix non-standard implementation of DWARF 5 DW_FORM_line_strp (7.5.5)

### DIFF
--- a/src/dwarf.cc
+++ b/src/dwarf.cc
@@ -202,6 +202,8 @@ string_view* File::GetFieldByName(string_view name) {
     return &debug_str;
   } else if (name == "str_offsets") {
     return &debug_str_offsets;
+  } else if (name == "line_str") {
+    return &debug_line_str;
   } else if (name == "info") {
     return &debug_info;
   } else if (name == "types") {

--- a/src/dwarf/attr.h
+++ b/src/dwarf/attr.h
@@ -107,6 +107,10 @@ class AttrValue {
   static absl::string_view ReadIndirectString(const CU& cu,
                                               absl::string_view* data);
   static absl::string_view ResolveIndirectString(const CU& cu, uint64_t ofs);
+  template <class D>
+  static absl::string_view ReadIndirectLineString(const CU& cu,
+                                              absl::string_view* data);
+  static absl::string_view ResolveIndirectLineString(const CU& cu, uint64_t ofs);
 
   absl::string_view ResolveDoubleIndirectString(const CU &cu) const;
   uint64_t ResolveIndirectAddress(const CU& cu) const;

--- a/src/dwarf/debug_info.h
+++ b/src/dwarf/debug_info.h
@@ -82,6 +82,7 @@ struct File {
   absl::string_view debug_rnglists;
   absl::string_view debug_str;
   absl::string_view debug_str_offsets;
+  absl::string_view debug_line_str;
   absl::string_view debug_types;
   const InputFile* file;
   OpenDwarf* open;

--- a/src/dwarf/dwarf_util.cc
+++ b/src/dwarf/dwarf_util.cc
@@ -66,9 +66,9 @@ void SkipLEB128(string_view* data) {
   THROW("corrupt DWARF data, unterminated LEB128");
 }
 
-absl::string_view ReadDebugStrEntry(absl::string_view debug_str, size_t ofs) {
-  SkipBytes(ofs, &debug_str);
-  return ReadNullTerminated(&debug_str);
+absl::string_view ReadDebugStrEntry(absl::string_view section, size_t ofs) {
+  SkipBytes(ofs, &section);
+  return ReadNullTerminated(&section);
 }
 
 }  // namespace dwarf

--- a/src/dwarf/dwarf_util.h
+++ b/src/dwarf/dwarf_util.h
@@ -47,7 +47,7 @@ inline int DivRoundUp(int n, int d) {
   return (n + (d - 1)) / d;
 }
 
-absl::string_view ReadDebugStrEntry(absl::string_view debug_str, size_t ofs);
+absl::string_view ReadDebugStrEntry(absl::string_view section, size_t ofs);
 
 }  // namepsace dwarf
 }  // namepsace bloaty

--- a/tests/dwarf/debug_info/dw_form_line_strp.test
+++ b/tests/dwarf/debug_info/dw_form_line_strp.test
@@ -1,0 +1,104 @@
+# Test that we can access DW_FORM_line_strp strings in the DWARF 5 debug_line_str section.
+
+# RUN: %yaml2obj %s --docnum=1 -o %t.obj
+# RUN: %yaml2obj %s --docnum=2 -o %t.dwo
+# RUN: %bloaty %t.obj --debug-file %t.dwo -d compileunits --raw-map --domain=vm | %FileCheck %s
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+  Entry:           0x1040
+ProgramHeaders:
+  - Type:            PT_LOAD
+    Flags:           [ PF_X, PF_R ]
+    FirstSec:        .text
+    LastSec:         .text
+    VAddr:           0x1000
+    Align:           0x1000
+Sections:
+  - Name:            .note.gnu.build-id
+    Type:            SHT_NOTE
+    Notes:
+      - Name:            GNU
+        Desc:            6CF422D909772A0FB5400518A689D9F15F14BF57
+        Type:            0x3  # NT_GNU_BUILD_ID
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1000
+    AddressAlign:    0x10
+    Size:            0x10
+  - Name:            .debug_line_str
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:         "666f6f2e6300" #foo.c
+...
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+  Entry:           0x1040
+Sections:
+  - Name:            .note.gnu.build-id
+    Type:            SHT_NOTE
+    Notes:
+      - Name:            GNU
+        Desc:            6CF422D909772A0FB5400518A689D9F15F14BF57
+        Type:            0x3  # NT_GNU_BUILD_ID
+  - Name:            .debug_line_str
+    Type:            SHT_PROGBITS
+    Flags:           [  ]
+    Content:         "666f6f2e6300" #foo.c
+DWARF:
+  # debug_line_str:        # <---- yaml2obj-15 "unknown key" error. instead, we use the section
+  #                        #       above similarly to:
+  #                        #       https://github.com/llvm/llvm-project/blob/8ce23b8e5c91c530d25c13f97b6f4cbacfe34b3c/llvm/test/tools/llvm-dwarfutil/ELF/X86/dwarf5-line-str.test#L2
+  #   - foo.c
+  debug_abbrev:
+    - ID:              0
+      Table:
+        - Code:            0x1
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_line_strp 
+        - Code:            0x2
+          Tag:             DW_TAG_subprogram
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_high_pc
+              Form:            DW_FORM_data4
+  debug_info:
+    # 0x0000000b: DW_TAG_compile_unit
+    #               DW_AT_name	("foo.c")
+    #
+    # 0x00000010:   DW_TAG_subprogram
+    #                 DW_AT_low_pc	(0x0000000000001000)
+    #                 DW_AT_high_pc	(0x0000000000001010)
+    - Version:         5
+      UnitType:        0x01 # DW_UT_compile
+      AbbrevTableID:   0
+      AbbrOffset:      0x0
+      AddrSize:        8
+      Entries:
+        - AbbrCode:        0x1
+          Values:
+            - Value:           0x0
+        - AbbrCode:        0x2
+          Values:
+            - Value:           0x1000
+            - Value:           0x10
+...
+
+# CHECK: VM MAP:
+# CHECK: 0000-1000              4096             [-- Nothing mapped --]
+# CHECK: 1000-1010                16             foo.c


### PR DESCRIPTION
The current implementation of  `DW_FORM_line_strp` reads into `.debug_str`. This form was added in DWARF 5, and the standard specifies that the string is included in the `.debug_line_str` section instead.

This PR fixes #348.