### PR TITLE
Update LLVM to 17.0.0-rc3 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: llvm/llvm-project
-          ref: llvmorg-13.0.0-rc1
+          ref: llvmorg-17.0.0-rc3
           path: llvm-project
           fetch-depth: 1
       - name: Get LLVM Revision
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: llvm/llvm-project
-          ref: llvmorg-13.0.0-rc1
+          ref: llvmorg-17.0.0-rc3
           path: llvm-project
           fetch-depth: 1
       - name: Get LLVM Revision
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: llvm/llvm-project
-          ref: llvmorg-13.0.0-rc1
+          ref: llvmorg-17.0.0-rc3
           path: llvm-project
           fetch-depth: 1
       - name: Get LLVM Revision


### PR DESCRIPTION
This is necessary to make #354's CI pass, but I thought it would be good to submit this standalone to see everything works fine with this before doing that.