### PR TITLE
Fix TOTAL row and % column output in diff mode

### DIFF
--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -276,6 +276,10 @@ class Rollup {
     row->filtered_size.file = filtered_file_total_;
     row->vmpercent = 100;
     row->filepercent = 100;
+    if (base) {
+      row->size.vm -= base->vm_total_;
+      row->size.file -= base->file_total_;
+    }
     output->diff_mode_ = true;
     CreateRows(row, base, options, true);
   }
@@ -399,8 +403,8 @@ void Rollup::CreateRows(RollupRow* row, const Rollup* base,
   if (base) {
     // For a diff, the percentage is a comparison against the previous size of
     // the same label at the same level.
-    row->vmpercent = Percent(vm_total_, base->vm_total_);
-    row->filepercent = Percent(file_total_, base->file_total_);
+    row->vmpercent = Percent(vm_total_ - base->vm_total_, base->vm_total_);
+    row->filepercent = Percent(file_total_ - base->file_total_, base->file_total_);
   }
 
   for (const auto& value : children_) {


### PR DESCRIPTION
Fixes google#361 and google#335.

Before:
```
    FILE SIZE        VM SIZE
 --------------  --------------
  +203% +1.46Ki  [ = ]       0    [Unmapped]
  +100%     +48  +100%     +48    .rodata
  +100%      -8  +100%      -8    .ARM.exidx
   +50%      -8   +50%      -8    .fini
  +100%     -12  +100%     -12    .ARM.extab
   +99% -5.48Ki   +99% -5.48Ki    .text
  +100% +1.72Mi  +100% +1.72Mi    TOTAL
```

After:
```
    FILE SIZE        VM SIZE
 --------------  --------------
  +103% +1.46Ki  [ = ]       0    [Unmapped]
  +0.0%     +48  +0.0%     +48    .rodata
  -0.0%      -8  -0.0%      -8    .ARM.exidx
 -50.0%      -8 -50.0%      -8    .fini
  -0.0%     -12  -0.0%     -12    .ARM.extab
  -0.5% -5.48Ki  -0.5% -5.48Ki    .text
  -0.2% -4.00Ki  -0.3% -5.46Ki    TOTAL
```