### PR TITLE
add_range: Replace THROW with WARN for early return

### DIFF
--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -1334,7 +1334,8 @@ void RangeSink::AddRange(const char* analyzer, string_view name,
   if (translator_) {
     if (!translator_->vm_map.CoversRange(vmaddr, vmsize) ||
         !translator_->file_map.CoversRange(fileoff, filesize)) {
-      THROW("Tried to add range that is not covered by base map.");
+      WARN("Tried to add range not covered by base map, range ignored.");
+      return;
     }
   }
 

--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -1334,7 +1334,9 @@ void RangeSink::AddRange(const char* analyzer, string_view name,
   if (translator_) {
     if (!translator_->vm_map.CoversRange(vmaddr, vmsize) ||
         !translator_->file_map.CoversRange(fileoff, filesize)) {
-      WARN("Tried to add range not covered by base map, range ignored.");
+      WARN("AddRange($0, $1, $2, $3, $4) will be ignored, because it is not "
+           "covered by base map.",
+           name.data(), vmaddr, vmsize, fileoff, filesize);
       return;
     }
   }


### PR DESCRIPTION
Replaces THROW statement from the RangeSink::AddRange function, to WARN, when the translator CoversRange test fails. This will allow for the operation to resume, while ignoring those failing ranges, instead of throwing an exception.