### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get LLVM Revision
         id: llvm-revision
         run: |
-          echo "::set-output name=revision::$(git -C ${{ github.workspace }}/llvm-project rev-parse HEAD)"
+          echo "revision=$(git -C ${{ github.workspace }}/llvm-project rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: actions/cache@v2
         id: llvm-build
         with:
@@ -77,7 +77,7 @@ jobs:
       - name: Get LLVM Revision
         id: llvm-revision
         run: |
-          echo "::set-output name=revision::$(git -C ${{ github.workspace }}/llvm-project rev-parse HEAD)"
+          echo "revision=$(git -C ${{ github.workspace }}/llvm-project rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: actions/cache@v2
         id: llvm-build
         with:
@@ -125,7 +125,7 @@ jobs:
       - name: Get LLVM Revision
         id: llvm-revision
         run: |
-          echo "::set-output name=revision::$(git -C ${{ github.workspace }}/llvm-project rev-parse HEAD)"
+          echo "revision=$(git -C ${{ github.workspace }}/llvm-project rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: actions/cache@v2
         id: llvm-build
         with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter