### PR TITLE
Link `absl::demangle_internal`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,7 @@ if(NOT absl_FOUND)
 endif()
 list(APPEND LIBBLOATY_LIBS absl::strings)
 list(APPEND LIBBLOATY_LIBS absl::optional)
+list(APPEND LIBBLOATY_LIBS absl::demangle_internal)
 list(APPEND LIBBLOATY_LIBS Threads::Threads)
 
 if(DEFINED ENV{LIB_FUZZING_ENGINE})


### PR DESCRIPTION
Also, update Abseil to fix a template type deduction failure.

Alternative to #384.

I'm a lot more conservative about the update to Abseil here, and CI should pass here. See:

https://github.com/carlocab/bloaty/actions/runs/10588615279
