### PR TITLE
Fix crash in StrictSubstr on `-ohos` artifacts

### DIFF
--- a/src/elf.cc
+++ b/src/elf.cc
@@ -416,7 +416,7 @@ void ElfFile::Section::ReadRelocationWithAddend(Elf64_Word index,
 }
 
 void ElfFile::NoteIter::Next() {
-  if (remaining_.empty()) {
+  if (remaining_.empty() || remaining_.compare("\0")) {
     done_ = true;
     return;
   }


### PR DESCRIPTION
Fixes a "region out-of-bounds" assertion failure in StrictSubstr when running bloaty on a Rust shared library compiled for `aarch64-unknown-linux-ohos`.

When `remaining_` is just the "\0" character, we are done and should return.