### PR TITLE
absl::string_view -> std::string_view

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         id: llvm-revision
         run: |
           echo "revision=$(git -C ${{ github.workspace }}/llvm-project rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: llvm-build
         with:
           path: ${{ github.workspace }}/build/llvm-project
@@ -78,7 +78,7 @@ jobs:
         id: llvm-revision
         run: |
           echo "revision=$(git -C ${{ github.workspace }}/llvm-project rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: llvm-build
         with:
           path: ${{ github.workspace }}/build/llvm-project
@@ -126,7 +126,7 @@ jobs:
         id: llvm-revision
         run: |
           echo "revision=$(git -C ${{ github.workspace }}/llvm-project rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: llvm-build
         with:
           path: ${{ github.workspace }}/build/llvm-project

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /bloaty
 !tests/testdata/**
 *.dSYM
+build
+build-*

--- a/src/disassemble.cc
+++ b/src/disassemble.cc
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 #include <string>
+#include <string_view>
 
 #include "absl/strings/ascii.h"
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/string_view.h"
 #include "absl/strings/substitute.h"
 #include "bloaty.h"
 #include "capstone/capstone.h"
 #include "re.h"
 #include "util.h"
 
-using absl::string_view;
+using std::string_view;
 
 namespace bloaty {
 

--- a/src/dwarf.cc
+++ b/src/dwarf.cc
@@ -21,13 +21,13 @@
 #include <limits>
 #include <memory>
 #include <stack>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "absl/base/attributes.h"
 #include "absl/base/macros.h"
-#include "absl/strings/string_view.h"
 #include "absl/strings/substitute.h"
 #include "absl/types/optional.h"
 #include "bloaty.h"
@@ -39,7 +39,7 @@
 #include "dwarf/line_info.h"
 
 using namespace dwarf2reader;
-using absl::string_view;
+using std::string_view;
 
 namespace bloaty {
 
@@ -446,7 +446,7 @@ void AddDIE(const dwarf::CU& cu, const GeneralDIE& die,
   if (die.location_uint64) {
     uint64_t location = *die.location_uint64;;
     if (location < cu.dwarf().debug_loc.size()) {
-      absl::string_view loc_range = cu.dwarf().debug_loc.substr(location);
+      std::string_view loc_range = cu.dwarf().debug_loc.substr(location);
       loc_range = GetLocationListRange(cu.unit_sizes(), loc_range);
       sink->AddFileRange("dwarf_locrange", cu.unit_name(), loc_range);
     } else if (verbose_level > 0) {
@@ -526,7 +526,7 @@ void AddDIE(const dwarf::CU& cu, const GeneralDIE& die,
 
     if (ranges_offset != UINT64_MAX) {
       if (ranges_offset < cu.dwarf().debug_ranges.size()) {
-        absl::string_view data = cu.dwarf().debug_ranges.substr(ranges_offset);
+        std::string_view data = cu.dwarf().debug_ranges.substr(ranges_offset);
         const char* start = data.data();
         ReadRangeList(cu, low_pc, cu.unit_name(), sink, &data);
         string_view all(start, data.data() - start);

--- a/src/dwarf/attr.cc
+++ b/src/dwarf/attr.cc
@@ -19,7 +19,7 @@
 #include "dwarf_constants.h"
 #include "util.h"
 
-using string_view = absl::string_view;
+using string_view = std::string_view;
 using namespace dwarf2reader;
 
 namespace bloaty {

--- a/src/dwarf/attr.h
+++ b/src/dwarf/attr.h
@@ -16,8 +16,8 @@
 #define BLOATY_DWARF_ATTR_H_
 
 #include <cstdint>
+#include <string_view>
 
-#include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 
 namespace bloaty {
@@ -27,7 +27,7 @@ class CU;
 
 class AttrValue {
  public:
-  static AttrValue ParseAttr(const CU& cu, uint16_t form, absl::string_view* data);
+  static AttrValue ParseAttr(const CU& cu, uint16_t form, std::string_view* data);
 
   AttrValue(const AttrValue &) = default;
   AttrValue &operator=(const AttrValue &) = default;
@@ -49,12 +49,12 @@ class AttrValue {
   uint64_t GetUint(const CU& cu) const;
 
   // REQUIRES: IsString().
-  absl::string_view GetString(const CU& cu) const;
+  std::string_view GetString(const CU& cu) const;
 
  private:
   explicit AttrValue(uint16_t form, uint64_t val)
       : uint_(val), form_(form), type_(Type::kUint) {}
-  explicit AttrValue(uint16_t form, absl::string_view val)
+  explicit AttrValue(uint16_t form, std::string_view val)
       : string_(val), form_(form), type_(Type::kString) {}
 
   // We delay the resolution of indirect strings and addresses, both to avoid
@@ -94,25 +94,25 @@ class AttrValue {
 
   union {
     uint64_t uint_;
-    absl::string_view string_;
+    std::string_view string_;
   };
 
   uint16_t form_;
   Type type_;
 
   template <class D>
-  static absl::string_view ReadBlock(absl::string_view* data);
-  static absl::string_view ReadVariableBlock(absl::string_view* data);
+  static std::string_view ReadBlock(std::string_view* data);
+  static std::string_view ReadVariableBlock(std::string_view* data);
   template <class D>
-  static absl::string_view ReadIndirectString(const CU& cu,
-                                              absl::string_view* data);
-  static absl::string_view ResolveIndirectString(const CU& cu, uint64_t ofs);
+  static std::string_view ReadIndirectString(const CU& cu,
+                                              std::string_view* data);
+  static std::string_view ResolveIndirectString(const CU& cu, uint64_t ofs);
   template <class D>
-  static absl::string_view ReadIndirectLineString(const CU& cu,
-                                              absl::string_view* data);
-  static absl::string_view ResolveIndirectLineString(const CU& cu, uint64_t ofs);
+  static std::string_view ReadIndirectLineString(const CU& cu,
+                                              std::string_view* data);
+  static std::string_view ResolveIndirectLineString(const CU& cu, uint64_t ofs);
 
-  absl::string_view ResolveDoubleIndirectString(const CU &cu) const;
+  std::string_view ResolveDoubleIndirectString(const CU &cu) const;
   uint64_t ResolveIndirectAddress(const CU& cu) const;
 };
 

--- a/src/dwarf/debug_info.cc
+++ b/src/dwarf/debug_info.cc
@@ -18,7 +18,7 @@
 
 using namespace dwarf2reader;
 
-using absl::string_view;
+using std::string_view;
 
 namespace bloaty {
 namespace dwarf {
@@ -74,8 +74,8 @@ void AbbrevTable::ReadAbbrevs(string_view data) {
   }
 }
 
-absl::string_view CompilationUnitSizes::ReadInitialLength(
-    absl::string_view* remaining) {
+std::string_view CompilationUnitSizes::ReadInitialLength(
+    std::string_view* remaining) {
   uint64_t len = ReadFixed<uint32_t>(remaining);
 
   if (len == 0xffffffff) {
@@ -89,7 +89,7 @@ absl::string_view CompilationUnitSizes::ReadInitialLength(
     THROW("short DWARF compilation unit");
   }
 
-  absl::string_view unit = *remaining;
+  std::string_view unit = *remaining;
   unit.remove_suffix(remaining->size() - len);
   *remaining = remaining->substr(len);
   return unit;

--- a/src/dwarf/debug_info.h
+++ b/src/dwarf/debug_info.h
@@ -49,9 +49,9 @@
 #define BLOATY_DWARF_DEBUG_INFO_H_
 
 #include <functional>
+#include <string_view>
 #include <unordered_map>
 
-#include "absl/strings/string_view.h"
 #include "absl/strings/substitute.h"
 #include "dwarf/attr.h"
 #include "dwarf/dwarf_util.h"
@@ -70,26 +70,26 @@ struct File;
 typedef void OpenDwarf(const InputFile &file, File *dwarf, RangeSink *sink);
 
 struct File {
-  absl::string_view debug_abbrev;
-  absl::string_view debug_addr;
-  absl::string_view debug_aranges;
-  absl::string_view debug_info;
-  absl::string_view debug_line;
-  absl::string_view debug_loc;
-  absl::string_view debug_pubnames;
-  absl::string_view debug_pubtypes;
-  absl::string_view debug_ranges;
-  absl::string_view debug_rnglists;
-  absl::string_view debug_str;
-  absl::string_view debug_str_offsets;
-  absl::string_view debug_line_str;
-  absl::string_view debug_types;
+  std::string_view debug_abbrev;
+  std::string_view debug_addr;
+  std::string_view debug_aranges;
+  std::string_view debug_info;
+  std::string_view debug_line;
+  std::string_view debug_loc;
+  std::string_view debug_pubnames;
+  std::string_view debug_pubtypes;
+  std::string_view debug_ranges;
+  std::string_view debug_rnglists;
+  std::string_view debug_str;
+  std::string_view debug_str_offsets;
+  std::string_view debug_line_str;
+  std::string_view debug_types;
   const InputFile* file;
   OpenDwarf* open;
 
-  absl::string_view* GetFieldByName(absl::string_view name);
-  void SetFieldByName(absl::string_view name, absl::string_view contents) {
-    absl::string_view *member = GetFieldByName(name);
+  std::string_view* GetFieldByName(std::string_view name);
+  void SetFieldByName(std::string_view name, std::string_view contents) {
+    std::string_view *member = GetFieldByName(name);
     if (member) *member = contents;
   }
 };
@@ -116,12 +116,12 @@ class CompilationUnitSizes {
 
   // Reads a DWARF offset based on whether we are reading dwarf32 or dwarf64
   // format.
-  uint64_t ReadDWARFOffset(absl::string_view* data) const {
+  uint64_t ReadDWARFOffset(std::string_view* data) const {
     return dwarf64_ ? ReadFixed<uint64_t>(data) : ReadFixed<uint32_t>(data);
   }
 
   // Reads an address according to the expected address_size.
-  uint64_t ReadAddress(absl::string_view* data) const {
+  uint64_t ReadAddress(std::string_view* data) const {
     return addr8_ ? ReadFixed<uint64_t>(data) : ReadFixed<uint32_t>(data);
   }
 
@@ -135,9 +135,9 @@ class CompilationUnitSizes {
   //
   // Returns the range for this section and stores the remaining data
   // in |remaining|.
-  absl::string_view ReadInitialLength(absl::string_view* remaining);
+  std::string_view ReadInitialLength(std::string_view* remaining);
 
-  void ReadDWARFVersion(absl::string_view* data) {
+  void ReadDWARFVersion(std::string_view* data) {
     dwarf_version_ = ReadFixed<uint16_t>(data);
   }
 
@@ -162,7 +162,7 @@ class CompilationUnitSizes {
 class AbbrevTable {
  public:
   // Reads abbreviations until a terminating abbreviation is seen.
-  void ReadAbbrevs(absl::string_view data);
+  void ReadAbbrevs(std::string_view data);
 
   // In a DWARF abbreviation, each attribute has a name and a form.
   struct Attribute {
@@ -179,7 +179,7 @@ class AbbrevTable {
   };
 
   bool IsEmpty() const { return abbrev_.empty(); }
-  absl::string_view abbrev_data() const { return abbrev_data_; }
+  std::string_view abbrev_data() const { return abbrev_data_; }
 
   // Looks for an abbreviation with the given code.  Returns true if the lookup
   // succeeded.
@@ -198,7 +198,7 @@ class AbbrevTable {
   // Generally we expect these to be small, so we could almost use a vector<>.
   // But you never know what crazy input data is going to do...
   std::unordered_map<uint32_t, Abbrev> abbrev_;
-  absl::string_view abbrev_data_;
+  std::string_view abbrev_data_;
 };
 
 class CUIter;
@@ -242,12 +242,12 @@ class CUIter {
 
  private:
   friend class InfoReader;
-  CUIter(InfoReader::Section section, absl::string_view next_unit)
+  CUIter(InfoReader::Section section, std::string_view next_unit)
       : section_(section), next_unit_(next_unit) {}
 
   // Data for the next compilation unit.
   InfoReader::Section section_;
-  absl::string_view next_unit_;
+  std::string_view next_unit_;
 };
 
 // CompilationUnit: stores info about a single compilation unit in .debug_info
@@ -260,20 +260,20 @@ class CU {
   const CU& skeleton() const { return *skeleton_; }
   const CompilationUnitSizes& unit_sizes() const { return unit_sizes_; }
   const std::string& unit_name() const { return unit_name_; }
-  absl::string_view entire_unit() const { return entire_unit_; }
+  std::string_view entire_unit() const { return entire_unit_; }
   uint64_t addr_base() const { return addr_base_; }
   uint64_t str_offsets_base() const { return str_offsets_base_; }
   uint64_t range_lists_base() const { return range_lists_base_; }
   const AbbrevTable& unit_abbrev() const { return *unit_abbrev_; }
 
-  void AddIndirectString(absl::string_view range) const {
+  void AddIndirectString(std::string_view range) const {
     if (strp_callback_) {
       strp_callback_(range);
     }
   }
 
   void SetIndirectStringCallback(
-      std::function<void(absl::string_view)> strp_sink) {
+      std::function<void(std::string_view)> strp_sink) {
     strp_callback_ = strp_sink;
   }
 
@@ -285,15 +285,15 @@ class CU {
   friend class CUIter;
   friend class DIEReader;
 
-  void ReadHeader(absl::string_view entire_unit, absl::string_view data,
+  void ReadHeader(std::string_view entire_unit, std::string_view data,
                   InfoReader::Section section, InfoReader& reader);
   void ReadTopLevelDIE(InfoReader& reader);
 
   const File* dwarf_;
 
   // Info that comes from the CU header.
-  absl::string_view entire_unit_;  // Entire CU's range.
-  absl::string_view data_;         // Entire unit excluding CU header.
+  std::string_view entire_unit_;  // Entire CU's range.
+  std::string_view data_;         // Entire unit excluding CU header.
   CompilationUnitSizes unit_sizes_;
   AbbrevTable* unit_abbrev_;
 
@@ -312,7 +312,7 @@ class CU {
   uint64_t str_offsets_base_ = 0;
   uint64_t range_lists_base_ = 0;
 
-  std::function<void(absl::string_view)> strp_callback_;
+  std::function<void(std::string_view)> strp_callback_;
 };
 
 // DIEReader: for reading a sequence of Debugging Information Entries in a
@@ -331,16 +331,16 @@ class DIEReader {
   // Internal APIs.
   friend class CU;
 
-  DIEReader(absl::string_view data) : remaining_(data) {}
+  DIEReader(std::string_view data) : remaining_(data) {}
   void SkipNullEntries();
 
   // Our current read position.
-  absl::string_view remaining_;
+  std::string_view remaining_;
   int depth_ = 0;
 };
 
 inline uint64_t ReadIndirectAddress(const CU& cu, uint64_t val) {
-  absl::string_view addrs = cu.skeleton().dwarf().debug_addr;
+  std::string_view addrs = cu.skeleton().dwarf().debug_addr;
   uint64_t base = cu.skeleton().addr_base();
   switch (cu.unit_sizes().address_size()) {
     case 4:

--- a/src/dwarf/dwarf_util.cc
+++ b/src/dwarf/dwarf_util.cc
@@ -14,7 +14,7 @@
 
 #include "dwarf/dwarf_util.h"
 
-using string_view = absl::string_view;
+using string_view = std::string_view;
 
 namespace bloaty {
 namespace dwarf {
@@ -66,7 +66,7 @@ void SkipLEB128(string_view* data) {
   THROW("corrupt DWARF data, unterminated LEB128");
 }
 
-absl::string_view ReadDebugStrEntry(absl::string_view section, size_t ofs) {
+std::string_view ReadDebugStrEntry(std::string_view section, size_t ofs) {
   SkipBytes(ofs, &section);
   return ReadNullTerminated(&section);
 }

--- a/src/dwarf/dwarf_util.h
+++ b/src/dwarf/dwarf_util.h
@@ -16,19 +16,19 @@
 #define BLOATY_DWARF_UTIL_H_
 
 #include <cstdint>
+#include <string_view>
 #include <type_traits>
 
-#include "absl/strings/string_view.h"
 #include "util.h"
 
 namespace bloaty {
 namespace dwarf {
 
-uint64_t ReadLEB128Internal(bool is_signed, absl::string_view* data);
+uint64_t ReadLEB128Internal(bool is_signed, std::string_view* data);
 
 // Reads a DWARF LEB128 varint, where high bits indicate continuation.
 template <typename T>
-T ReadLEB128(absl::string_view* data) {
+T ReadLEB128(std::string_view* data) {
   typedef typename std::conditional<std::is_signed<T>::value, int64_t,
                                     uint64_t>::type Int64Type;
   Int64Type val = ReadLEB128Internal(std::is_signed<T>::value, data);
@@ -39,7 +39,7 @@ T ReadLEB128(absl::string_view* data) {
   return static_cast<T>(val);
 }
 
-void SkipLEB128(absl::string_view* data);
+void SkipLEB128(std::string_view* data);
 
 bool IsValidDwarfAddress(uint64_t addr, uint8_t address_size);
 
@@ -47,7 +47,7 @@ inline int DivRoundUp(int n, int d) {
   return (n + (d - 1)) / d;
 }
 
-absl::string_view ReadDebugStrEntry(absl::string_view section, size_t ofs);
+std::string_view ReadDebugStrEntry(std::string_view section, size_t ofs);
 
 }  // namepsace dwarf
 }  // namepsace bloaty

--- a/src/dwarf/line_info.cc
+++ b/src/dwarf/line_info.cc
@@ -18,7 +18,7 @@
 #include "dwarf_constants.h"
 
 using namespace dwarf2reader;
-using absl::string_view;
+using std::string_view;
 
 namespace bloaty {
 
@@ -39,7 +39,7 @@ const std::string& LineInfoReader::GetExpandedFilename(size_t index) {
   std::string& ret = expanded_filenames_[index];
   if (ret.empty()) {
     const FileName& filename = filenames_[index];
-    absl::string_view directory = include_directories_[filename.directory_index];
+    std::string_view directory = include_directories_[filename.directory_index];
     ret = std::string(directory);
     if (!ret.empty()) {
       ret += "/";

--- a/src/dwarf/line_info.h
+++ b/src/dwarf/line_info.h
@@ -16,8 +16,8 @@
 #define BLOATY_DWARF_LINE_INFO_H_
 
 #include <cstdint>
+#include <string_view>
 
-#include "absl/strings/string_view.h"
 #include "dwarf/debug_info.h"
 
 // Code to read the .line_info programs in a DWARF file.  Currently we use this
@@ -57,7 +57,7 @@ class LineInfoReader {
   };
 
   struct FileName {
-    absl::string_view name;
+    std::string_view name;
     uint32_t directory_index;
     uint64_t modified_time;
     uint64_t file_size;
@@ -67,7 +67,7 @@ class LineInfoReader {
   bool ReadLineInfo();
   const LineInfo& lineinfo() const { return info_; }
   const FileName& filename(size_t i) const { return filenames_[i]; }
-  absl::string_view include_directory(size_t i) const {
+  std::string_view include_directory(size_t i) const {
     return include_directories_[i];
   }
 
@@ -86,12 +86,12 @@ class LineInfoReader {
   const File& file_;
 
   CompilationUnitSizes sizes_;
-  std::vector<absl::string_view> include_directories_;
+  std::vector<std::string_view> include_directories_;
   std::vector<FileName> filenames_;
   std::vector<uint8_t> standard_opcode_lengths_;
   std::vector<std::string> expanded_filenames_;
 
-  absl::string_view remaining_;
+  std::string_view remaining_;
 
   // Whether we are in a "shadow" part of the bytecode program.  Sometimes
   // parts of the line info program make it into the final binary even though

--- a/src/eh_frame.cc
+++ b/src/eh_frame.cc
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string_view>
+
 #include "bloaty.h"
 #include "util.h"
-#include "absl/strings/string_view.h"
 #include "dwarf_constants.h"
 #include "dwarf/dwarf_util.h"
 
-using absl::string_view;
+using std::string_view;
 using namespace dwarf2reader;
 
 namespace bloaty {

--- a/src/macho.cc
+++ b/src/macho.cc
@@ -18,16 +18,16 @@
 #include "util.h"
 
 #include <cassert>
+#include <string_view>
 
 #include "absl/strings/str_join.h"
-#include "absl/strings/string_view.h"
 #include "absl/strings/substitute.h"
 #include "third_party/darwin_xnu_macho/mach-o/loader.h"
 #include "third_party/darwin_xnu_macho/mach-o/fat.h"
 #include "third_party/darwin_xnu_macho/mach-o/nlist.h"
 #include "third_party/darwin_xnu_macho/mach-o/reloc.h"
 
-using absl::string_view;
+using std::string_view;
 
 namespace bloaty {
 namespace macho {
@@ -599,7 +599,7 @@ class MachOObjectFile : public ObjectFile {
     }
   }
 
-  bool GetDisassemblyInfo(absl::string_view /*symbol*/,
+  bool GetDisassemblyInfo(std::string_view /*symbol*/,
                           DataSource /*symbol_source*/,
                           DisassemblyInfo* /*info*/) const override {
     WARN("Mach-O files do not support disassembly yet");

--- a/src/pe.cc
+++ b/src/pe.cc
@@ -16,7 +16,7 @@
 #include "bloaty.h"
 #include "util.h"
 
-using absl::string_view;
+using std::string_view;
 using std::string;
 
 namespace bloaty {
@@ -193,7 +193,7 @@ void ParseSections(const PeFile& pe, RangeSink* sink) {
   ForEachSection(pe, [sink, &pe](const Section& section) {
     uint64_t vmaddr = section.virtual_addr();
     uint64_t vmsize = section.virtual_size();
-    absl::string_view section_data = StrictSubstr(
+    std::string_view section_data = StrictSubstr(
         pe.entire_file(), section.raw_offset(), section.raw_size());
 
     sink->AddRange("pe_sections", section.name, vmaddr, vmsize, section_data);

--- a/src/source_map.h
+++ b/src/source_map.h
@@ -17,12 +17,12 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
+
 #include "bloaty.h"
 #include "util.h"
-
-#include "absl/strings/string_view.h"
 
 namespace bloaty {
 namespace sourcemap {
@@ -41,7 +41,7 @@ class SourceMapObjectFile : public ObjectFile {
     WARN("General processing not supported for source map files");
   }
 
-  bool GetDisassemblyInfo(absl::string_view /*symbol*/,
+  bool GetDisassemblyInfo(std::string_view /*symbol*/,
                           DataSource /*symbol_source*/,
                           DisassemblyInfo* /*info*/) const override {
     WARN("Disassembly not supported for source map files");

--- a/src/util.cc
+++ b/src/util.cc
@@ -14,7 +14,7 @@
 
 #include "util.h"
 
-using absl::string_view;
+using std::string_view;
 
 namespace bloaty {
 
@@ -23,8 +23,8 @@ void Throw(const char *str, int line) {
   throw bloaty::Error(str, __FILE__, line);
 }
 
-absl::string_view ReadUntilConsuming(absl::string_view* data, char c) {
-  absl::string_view ret = ReadUntil(data, c);
+std::string_view ReadUntilConsuming(std::string_view* data, char c) {
+  std::string_view ret = ReadUntil(data, c);
 
   if (data->empty() || data->front() != c) {
     // Nothing left, meaning we didn't find the terminating character.
@@ -38,17 +38,17 @@ absl::string_view ReadUntilConsuming(absl::string_view* data, char c) {
   return ret;
 }
 
-absl::string_view ReadUntil(absl::string_view* data, char c) {
+std::string_view ReadUntil(std::string_view* data, char c) {
   const char* found =
       static_cast<const char*>(memchr(data->data(), c, data->size()));
 
   size_t len = (found == NULL) ? data->size() : (found - data->data());
-  absl::string_view val = data->substr(0, len);
+  std::string_view val = data->substr(0, len);
   data->remove_prefix(len);
   return val;
 }
 
-void SkipWhitespace(absl::string_view* data) {
+void SkipWhitespace(std::string_view* data) {
   const char* c = data->data();
   const char* limit = c + data->size();
   while (c < limit) {

--- a/src/util.h
+++ b/src/util.h
@@ -16,9 +16,9 @@
 #define BLOATY_UTIL_H_
 
 #include <stdexcept>
+#include <string_view>
 
 #include "absl/numeric/int128.h"
-#include "absl/strings/string_view.h"
 #include "absl/strings/substitute.h"
 
 namespace bloaty {
@@ -86,7 +86,7 @@ inline uint64_t CheckedMul(uint64_t a, uint64_t b) {
   return static_cast<uint64_t>(c);
 }
 
-inline absl::string_view StrictSubstr(absl::string_view data, size_t off,
+inline std::string_view StrictSubstr(std::string_view data, size_t off,
                                       size_t n) {
   uint64_t end = CheckedAdd(off, n);
   if (end > data.size()) {
@@ -95,7 +95,7 @@ inline absl::string_view StrictSubstr(absl::string_view data, size_t off,
   return data.substr(off, n);
 }
 
-inline absl::string_view StrictSubstr(absl::string_view data, size_t off) {
+inline std::string_view StrictSubstr(std::string_view data, size_t off) {
   if (off > data.size()) {
     THROW("region out-of-bounds");
   }
@@ -134,7 +134,7 @@ template <class T> constexpr T ByteSwap(T val) {
     return _BS<sizeof(T)>(val);
 }
 
-template <class T, size_t N = sizeof(T)> T ReadFixed(absl::string_view *data) {
+template <class T, size_t N = sizeof(T)> T ReadFixed(std::string_view *data) {
   static_assert(N <= sizeof(T), "N too big for this data type");
   T val = 0;
   if (data->size() < N) {
@@ -145,39 +145,39 @@ template <class T, size_t N = sizeof(T)> T ReadFixed(absl::string_view *data) {
   return val;
 }
 
-template <class T> T ReadEndian(absl::string_view *data, Endian endian) {
+template <class T> T ReadEndian(std::string_view *data, Endian endian) {
   T val = ReadFixed<T>(data);
   return endian == GetMachineEndian() ? val : ByteSwap(val);
 }
 
-template <class T> T ReadLittleEndian(absl::string_view *data) {
+template <class T> T ReadLittleEndian(std::string_view *data) {
   return ReadEndian<T>(data, Endian::kLittle);
 }
 
-template <class T> T ReadBigEndian(absl::string_view *data) {
+template <class T> T ReadBigEndian(std::string_view *data) {
   return ReadEndian<T>(data, Endian::kBig);
 }
 
 // General data reading  ///////////////////////////////////////////////////////
 
-absl::string_view ReadUntil(absl::string_view* data, char c);
+std::string_view ReadUntil(std::string_view* data, char c);
 
-absl::string_view ReadUntilConsuming(absl::string_view* data, char c);
+std::string_view ReadUntilConsuming(std::string_view* data, char c);
 
-inline absl::string_view ReadNullTerminated(absl::string_view* data) {
+inline std::string_view ReadNullTerminated(std::string_view* data) {
   return ReadUntilConsuming(data, '\0');
 }
 
-inline absl::string_view ReadBytes(size_t bytes, absl::string_view* data) {
+inline std::string_view ReadBytes(size_t bytes, std::string_view* data) {
   if (data->size() < bytes) {
     THROW("premature EOF reading variable-length DWARF data");
   }
-  absl::string_view ret = data->substr(0, bytes);
+  std::string_view ret = data->substr(0, bytes);
   data->remove_prefix(bytes);
   return ret;
 }
 
-inline void RequireChar(absl::string_view* data, char c) {
+inline void RequireChar(std::string_view* data, char c) {
   if (data->empty() || data->front() != c) {
     THROWF("unexpected '$0', expected '$1'",
            data->empty() ? "EOF" : data->substr(0, 1), c);
@@ -185,11 +185,11 @@ inline void RequireChar(absl::string_view* data, char c) {
   data->remove_prefix(1);
 }
 
-inline void SkipBytes(size_t bytes, absl::string_view* data) {
+inline void SkipBytes(size_t bytes, std::string_view* data) {
   ReadBytes(bytes, data);  // Discard result.
 }
 
-void SkipWhitespace(absl::string_view* data);
+void SkipWhitespace(std::string_view* data);
 
 }  // namespace bloaty
 

--- a/src/webassembly.cc
+++ b/src/webassembly.cc
@@ -18,7 +18,7 @@
 
 #include "absl/strings/substitute.h"
 
-using absl::string_view;
+using std::string_view;
 
 namespace bloaty {
 namespace wasm {
@@ -473,7 +473,7 @@ class WebAssemblyObjectFile : public ObjectFile {
     }
   }
 
-  bool GetDisassemblyInfo(absl::string_view /*symbol*/,
+  bool GetDisassemblyInfo(std::string_view /*symbol*/,
                           DataSource /*symbol_source*/,
                           DisassemblyInfo* /*info*/) const override {
     WARN("WebAssembly files do not support disassembly yet");

--- a/tests/fuzz_target.cc
+++ b/tests/fuzz_target.cc
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string_view>
+
 #include "bloaty.h"
 #include "bloaty.pb.h"
 #include "strarr.h"
 
-#include "absl/strings/string_view.h"
-
-using absl::string_view;
+using std::string_view;
 
 namespace bloaty {
 
@@ -29,7 +29,7 @@ class StringPieceInputFile : public InputFile {
     data_ = data;
   }
 
-  bool TryOpen(absl::string_view /* filename */,
+  bool TryOpen(std::string_view /* filename */,
                std::unique_ptr<InputFile>& file) override {
     file.reset(new StringPieceInputFile(data_));
     return true;


### PR DESCRIPTION
Now that we depend on C++17, there is no need to use the
ABSL version.