### PR TITLE
Prevent size underflow in dwarf ReadRangeList

### DIFF
--- a/src/dwarf.cc
+++ b/src/dwarf.cc
@@ -185,6 +185,8 @@ void ReadRangeList(const CU& cu, uint64_t low_pc, string_view name,
       return;
     } else if (start == max_address) {
       low_pc = end;
+    } else if (end == 0) {
+      return;
     } else {
       uint64_t size = end - start;
       sink->AddVMRangeIgnoreDuplicate("dwarf_rangelist", low_pc + start, size,


### PR DESCRIPTION
If end is 0, we get a size underflow and bloaty crashes later with `Overflow in vm range` as the last message.

Possible fix for #382 (it at least fixed / hid the issue I ran into on the binary i tested)