### PR TITLE
Fix a typo in the DWARF attr parser

### DIFF
--- a/src/dwarf/attr.cc
+++ b/src/dwarf/attr.cc
@@ -38,7 +38,7 @@ absl::optional<uint64_t> AttrValue::ToUint(const CU& cu) const {
     case 1:
       return ReadFixed<uint8_t>(&str);
     case 2:
-      return ReadFixed<uint8_t>(&str);
+      return ReadFixed<uint16_t>(&str);
     case 4:
       return ReadFixed<uint32_t>(&str);
     case 8:


### PR DESCRIPTION
I'm not sure if this actually affects any of the Bloaty features but I was reusing the DWARF parsing code for a separate project and noticed something was off there.