### PR TITLE
Add support for tags in import section.

### DIFF
--- a/src/webassembly.cc
+++ b/src/webassembly.cc
@@ -163,6 +163,7 @@ struct ExternalKind {
     kTable = 1,
     kMemory = 2,
     kGlobal = 3,
+    kTag = 4,
   };
 };
 
@@ -267,6 +268,11 @@ void ReadMemoryType(string_view* data) {
   ReadResizableLimits(data);
 }
 
+void ReadTagType(string_view* data) {
+  ReadFixed<uint8_t>(data);
+  ReadVarUInt32(data);
+}
+
 uint32_t GetNumFunctionImports(const Section& section) {
   assert(section.id == Section::kImport);
   string_view data = section.contents;
@@ -294,6 +300,9 @@ uint32_t GetNumFunctionImports(const Section& section) {
         break;
       case ExternalKind::kGlobal:
         ReadGlobalType(&data);
+        break;
+      case ExternalKind::kTag:
+        ReadTagType(&data);
         break;
       default:
         THROWF("Unrecognized import kind: $0", kind);


### PR DESCRIPTION
Bloaty fails with "Unrecognized import kind: 4" when there is a tag in import section.

Minimum example:
```
cat > example.cpp <<EOF
#include <emscripten.h>
EMSCRIPTEN_KEEPALIVE void foo() { throw "error"; }
EOF
em++ example.cpp -sMAIN_MODULE=2 -fwasm-exceptions -o example.wasm
bloaty -d symbols example.wasm
```