### PR TITLE
Udpate fuzzer workflow

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -22,7 +22,7 @@ jobs:
        dry-run: false
        sanitizer: ${{ matrix.sanitizer }}
    - name: Upload Crash
-     uses: actions/upload-artifact@v1
+     uses: actions/upload-artifact@v4
      if: failure()
      with:
        name: ${{ matrix.sanitizer }}-artifacts


### PR DESCRIPTION
Use the latest version of the upload artifact action to fix CI failures.

Fixes #415