### PR TITLE
Target C++ 20 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(POLICY CMP0091)
 endif()
 project (Bloaty VERSION 1.1)
 include(CTest)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)  # Group projects in visual studio
 
 # Options we define for users.


### PR DESCRIPTION
Update cmake to target c++ 20 by default. This may help with updating `bloaty`s dependencies.