### PR TITLE
Support LC_DYLD_CHAINED_FIXUPS and LC_DYLD_EXPORTS_TRIE load commands

### DIFF
--- a/src/macho.cc
+++ b/src/macho.cc
@@ -405,6 +405,12 @@ void ParseLoadCommand(const LoadCommand& cmd, RangeSink* sink) {
     case LC_LINKER_OPTIMIZATION_HINT:
       ParseLinkeditCommand("Optimization Hints", cmd, sink);
       break;
+    case LC_DYLD_CHAINED_FIXUPS:
+      ParseLinkeditCommand("Chained Fixups", cmd, sink);
+      break;
+    case LC_DYLD_EXPORTS_TRIE:
+      ParseLinkeditCommand("Exports Trie", cmd, sink);
+      break;
   }
 }
 


### PR DESCRIPTION
Modern macOS binaries use these for chained fixups and export tries.