### PR TITLE
Prevent size underflow in dwarf ReadRangeList

### DIFF
--- a/src/dwarf.cc
+++ b/src/dwarf.cc
@@ -185,6 +185,8 @@ void ReadRangeList(const CU& cu, uint64_t low_pc, string_view name,
       return;
     } else if (start == max_address) {
       low_pc = end;
+    } else if (end < start) {
+      WARN("DWARF end < start for $0: $1 < $2", name_str, end, start);
     } else {
       uint64_t size = end - start;
       sink->AddVMRangeIgnoreDuplicate("dwarf_rangelist", low_pc + start, size,
@@ -391,6 +393,11 @@ uint64_t TryReadPcPair(const dwarf::CU& cu, const GeneralDIE& die,
   addr = *die.low_pc;
 
   if (die.high_pc_addr) {
+    if (*die.high_pc_addr < addr) {
+      WARN("DWARF high_pc < low_pc for $0: $1 < $2", cu.unit_name(),
+           *die.high_pc_addr, addr);
+      return 0;
+    }
     size = *die.high_pc_addr - addr;
   } else if (die.high_pc_size) {
     size = *die.high_pc_size;

--- a/tests/dwarf/debug_info/invalid-range.test
+++ b/tests/dwarf/debug_info/invalid-range.test
@@ -1,0 +1,63 @@
+# Test that we ignore invalid ranges where high_pc < low_pc.
+#
+# RUN: %yaml2obj %s -o %t.o
+# RUN: %bloaty %t.o -d compileunits --raw-map --domain=vm | %FileCheck %s
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+ProgramHeaders:
+  - Type:            PT_LOAD
+    Flags:           [ PF_X, PF_R ]
+    FirstSec:        .text
+    LastSec:         .text
+    VAddr:           0x1000
+    Align:           0x1000
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1000
+    Size:            0x30
+DWARF:
+  debug_str:
+    - invalid.c
+  debug_abbrev:
+    - ID:              0
+      Table:
+        - Code:            0x1
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+        - Code:            0x2
+          Tag:             DW_TAG_subprogram
+          Children:        DW_CHILDREN_no
+          Attributes:
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+            - Attribute:       DW_AT_high_pc
+              Form:            DW_FORM_addr
+  debug_info:
+    # Invalid CU (high_pc < low_pc)
+    - Version:         4
+      AbbrevTableID:   0
+      AddrSize:        8
+      Entries:
+        - AbbrCode:        0x1
+          Values:
+            - Value:           0x0  # offset into debug_str for "invalid.c"
+        - AbbrCode:        0x2
+          Values:
+            - Value:           0x1010  # low_pc
+            - Value:           0x1000  # high_pc (INVALID: less than low_pc)
+        - AbbrCode:        0x0
+...
+
+# CHECK: VM MAP:
+# CHECK: 0000-1000              4096             [-- Nothing mapped --]
+# CHECK: 1000-1030                48             [section .text]

--- a/tests/dwarf/range_lists/invalid-range.test
+++ b/tests/dwarf/range_lists/invalid-range.test
@@ -1,0 +1,64 @@
+# Test that we ignore invalid ranges where end < start in debug_ranges.
+#
+# RUN: %yaml2obj %s -o %t.o
+# RUN: %bloaty %t.o -d compileunits --raw-map --domain=vm | %FileCheck %s
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_X86_64
+ProgramHeaders:
+  - Type:            PT_LOAD
+    Flags:           [ PF_X, PF_R ]
+    FirstSec:        .text
+    LastSec:         .text
+    VAddr:           0x1000
+    Align:           0x1000
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    Address:         0x1000
+    Size:            0x30
+DWARF:
+  debug_str:
+    - test.c
+  debug_abbrev:
+    - ID:              0
+      Table:
+        - Code:            0x1
+          Tag:             DW_TAG_compile_unit
+          Children:        DW_CHILDREN_yes
+          Attributes:
+            - Attribute:       DW_AT_name
+              Form:            DW_FORM_strp
+            - Attribute:       DW_AT_ranges
+              Form:            DW_FORM_sec_offset
+            - Attribute:       DW_AT_low_pc
+              Form:            DW_FORM_addr
+  debug_ranges:
+    - Offset:          0x0
+      AddrSize:        0x8
+      Entries:
+        - LowOffset:       0x1020
+          HighOffset:      0x1015  # INVALID: end < start
+        - LowOffset:       0x0
+          HighOffset:      0x0
+  debug_info:
+    - Version:         4
+      AbbrevTableID:   0
+      AddrSize:        8
+      Entries:
+        - AbbrCode:        0x1
+          Values:
+            - Value:           0x0  # test.c
+            - Value:           0x0  # ranges offset
+            - Value:           0x0  # low_pc
+        - AbbrCode:        0x0
+...
+
+# CHECK: VM MAP:
+# CHECK: 0000-1000              4096             [-- Nothing mapped --]
+# CHECK: 1000-1030                48             [section .text]


### PR DESCRIPTION
Gracefully handle if a range entry has a lower end than start. This adds warnings which can be seen with `-v` and adds two tests to verify the original problem as well as the fixes.

Fixes #382