### PR TITLE
Fix compiler warnings across source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,8 @@ if(BLOATY_ENABLE_RE2)
   add_definitions(-DUSE_RE2)
 endif()
 
+include(CheckCXXCompilerFlag)
+
 # Set MSVC runtime before including thirdparty libraries
 if(MSVC)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
@@ -147,6 +149,21 @@ if(UNIX OR MINGW)
     set(protobuf_BUILD_SHARED_LIBS OFF CACHE BOOL "enable shared libs for proto2" FORCE)
     add_subdirectory(third_party/protobuf)
     include_directories(SYSTEM third_party/protobuf/src)
+
+    # Work around gcc warning in protobuf's message_lite.cc
+    # See https://github.com/protocolbuffers/protobuf/issues/6419
+    CHECK_CXX_COMPILER_FLAG("-Wno-stringop-overflow" COMPILER_SUPPORTS_WNO_STRINGOP_OVERFLOW)
+    CHECK_CXX_COMPILER_FLAG("-Wno-stringop-overread" COMPILER_SUPPORTS_WNO_STRINGOP_OVERREAD)
+    if(COMPILER_SUPPORTS_WNO_STRINGOP_OVERFLOW)
+      target_compile_options(libprotobuf PRIVATE -Wno-stringop-overflow)
+      target_compile_options(libprotobuf-lite PRIVATE -Wno-stringop-overflow)
+      target_compile_options(libprotoc PRIVATE -Wno-stringop-overflow)
+    endif()
+    if(COMPILER_SUPPORTS_WNO_STRINGOP_OVERREAD)
+      target_compile_options(libprotobuf PRIVATE -Wno-stringop-overread)
+      target_compile_options(libprotobuf-lite PRIVATE -Wno-stringop-overread)
+      target_compile_options(libprotoc PRIVATE -Wno-stringop-overread)
+    endif()
   endif()
   if(NOT ZLIB_FOUND)
     init_submodule(third_party/zlib)
@@ -185,6 +202,21 @@ else()
     set_property(TARGET libprotobuf-lite PROPERTY CXX_STANDARD 20)
     set_property(TARGET libprotoc PROPERTY CXX_STANDARD 20)
     set_property(TARGET protoc PROPERTY CXX_STANDARD 20)
+  endif()
+
+  # Work around gcc warning in protobuf's message_lite.cc
+  # See https://github.com/protocolbuffers/protobuf/issues/6419
+  CHECK_CXX_COMPILER_FLAG("-Wno-stringop-overflow" COMPILER_SUPPORTS_WNO_STRINGOP_OVERFLOW)
+  CHECK_CXX_COMPILER_FLAG("-Wno-stringop-overread" COMPILER_SUPPORTS_WNO_STRINGOP_OVERREAD)
+  if(COMPILER_SUPPORTS_WNO_STRINGOP_OVERFLOW)
+    target_compile_options(libprotobuf PRIVATE -Wno-stringop-overflow)
+    target_compile_options(libprotobuf-lite PRIVATE -Wno-stringop-overflow)
+    target_compile_options(libprotoc PRIVATE -Wno-stringop-overflow)
+  endif()
+  if(COMPILER_SUPPORTS_WNO_STRINGOP_OVERREAD)
+    target_compile_options(libprotobuf PRIVATE -Wno-stringop-overread)
+    target_compile_options(libprotobuf-lite PRIVATE -Wno-stringop-overread)
+    target_compile_options(libprotoc PRIVATE -Wno-stringop-overread)
   endif()
 
   init_submodule(third_party/zlib)
@@ -245,7 +277,6 @@ elseif(UNIX)
 endif()
 
 # When using Ninja, compiler output won't be colorized without this.
-include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG(-fdiagnostics-color=always SUPPORTS_COLOR_ALWAYS)
 if(SUPPORTS_COLOR_ALWAYS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")

--- a/src/pe.cc
+++ b/src/pe.cc
@@ -25,11 +25,11 @@ constexpr uint16_t dos_magic = 0x5A4D;  // MZ
 
 // From LIEF/include/LIEF/PE/Structures.hpp.in
 //! Sizes in bytes of various things in the COFF format.
-constexpr size_t kHeader16Size = 20;
-constexpr size_t kHeader32Size = 56;
+[[maybe_unused]] constexpr size_t kHeader16Size = 20;
+[[maybe_unused]] constexpr size_t kHeader32Size = 56;
 constexpr size_t kNameSize = 8;
 constexpr size_t kSymbol16Size = 18;
-constexpr size_t kSymbol32Size = 20;
+[[maybe_unused]] constexpr size_t kSymbol32Size = 20;
 constexpr size_t kSectionSize = 40;
 constexpr size_t kRelocationSize = 10;
 constexpr size_t kBaseRelocationBlockSize = 8;

--- a/src/source_map.h
+++ b/src/source_map.h
@@ -37,7 +37,7 @@ class SourceMapObjectFile : public ObjectFile {
     return build_id_;
   }
 
-  void ProcessFile(const std::vector<RangeSink*>& sinks) const override {
+  void ProcessFile(const std::vector<RangeSink*>& /*sinks*/) const override {
     WARN("General processing not supported for source map files");
   }
 

--- a/tests/bloaty_test.cc
+++ b/tests/bloaty_test.cc
@@ -249,7 +249,7 @@ TEST_F(BloatyTest, SimpleBinary) {
 TEST_F(BloatyTest, InputFiles) {
   std::string file1 = "05-binary.bin";
   std::string file2 = "07-binary-stripped.bin";
-  uint64_t size1, size2;
+  uint64_t size1 = 0, size2 = 0;
   ASSERT_TRUE(GetFileSize(file1, &size1));
   ASSERT_TRUE(GetFileSize(file2, &size2));
   RunBloaty({"bloaty", file1, file2, "-d", "inputfiles"});


### PR DESCRIPTION
Mark unused parameters and constants appropriately. 
Suppress GCC -Wstringop-overflow and -Wstringop-overread in protobuf (see protocolbuffers/protobuf#6419).

Fixes #405