### PR TITLE
Fix config file handling of max_rows_per_level: 0

### DIFF
--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -2170,6 +2170,11 @@ bool DoParseOptions(bool skip_unknown, int* argc, char** argv[],
       if (!google::protobuf::TextFormat::Merge(&stream, options)) {
         THROWF("error parsing configuration out of file $0", option);
       }
+      // max_rows_per_level: 0 means "show all rows" (same as -n 0)
+      if (options->has_max_rows_per_level() &&
+          options->max_rows_per_level() == 0) {
+        options->set_max_rows_per_level(INT64_MAX);
+      }
     } else if (args.TryParseOption("-d", &option)) {
       std::vector<std::string> names = absl::StrSplit(option, ',');
       for (const auto& name : names) {

--- a/tests/bloaty_test.cc
+++ b/tests/bloaty_test.cc
@@ -55,6 +55,13 @@ TEST_F(BloatyTest, SimpleObjectFile) {
   EXPECT_EQ(top_row_->size.file, size);
   EXPECT_GT(top_row_->sorted_children.size(), 1);
 
+  // Test that max_rows_per_level: 0 in config works the same as -n 0
+  RunBloaty({"bloaty", "-c", "../max_rows_zero.bloaty", file});
+  EXPECT_GT(top_row_->size.vm, 64);
+  EXPECT_LT(top_row_->size.vm, 300);
+  EXPECT_EQ(top_row_->size.file, size);
+  EXPECT_GT(top_row_->sorted_children.size(), 1);
+
   // Same with segments (we fake segments on .o files).
   RunBloaty({"bloaty", "-d", "segments", file});
   EXPECT_GT(top_row_->size.vm, 64);

--- a/tests/testdata/max_rows_zero.bloaty
+++ b/tests/testdata/max_rows_zero.bloaty
@@ -1,0 +1,2 @@
+data_source: "sections"
+max_rows_per_level: 0


### PR DESCRIPTION
The command line option -n 0 has handling to convert 0 to INT64_MAX for "unlimited", but the config file option max_rows_per_level: 0 was not doing the same.

Fixes #375