### PR TITLE
Fix system capstone include path for misconfigured pkg-config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,12 @@ if(UNIX OR MINGW)
     endif()
   endif()
   if(CAPSTONE_FOUND)
+    # Work around pkg-config files that incorrectly point to include/capstone
+    # instead of include e.g. homebrew's capstone package
+    get_filename_component(CAPSTONE_DIR_NAME "${CAPSTONE_INCLUDE_DIRS}" NAME)
+    if(CAPSTONE_DIR_NAME STREQUAL "capstone")
+      get_filename_component(CAPSTONE_INCLUDE_DIRS "${CAPSTONE_INCLUDE_DIRS}" DIRECTORY)
+    endif()
     include_directories(${CAPSTONE_INCLUDE_DIRS})
   else()
     init_submodule(third_party/capstone)


### PR DESCRIPTION
Some pkg-config files incorrectly set the include directory to <path/to/include>/capstone instead of <path/to/include>. Since bloaty uses #include "capstone/capstone.h", it expects the parent directory.

This fix detects when the pkg-config path ends with /capstone and strips it, ensuring compatibility with both correct and incorrect pkg-config files.

Fixes #342