### PR TITLE
Fix incorrect error message for -d inlines on ELF object files

### DIFF
--- a/src/elf.cc
+++ b/src/elf.cc
@@ -1335,7 +1335,7 @@ class ElfObjectFile : public ObjectFile {
           break;
         }
         case DataSource::kInlines: {
-          CheckNotObject("lineinfo", sink);
+          CheckNotObject("inlines", sink);
           dwarf::File dwarf;
           ReadDWARFSections(debug_file().file_data(), &dwarf, sink);
           ReadDWARFInlines(dwarf, sink, true);


### PR DESCRIPTION
The error message incorrectly said 'lineinfo' instead of 'inlines' when attempting to use -d inlines on an ELF object file. There is no 'lineinfo' data source in bloaty.