### PR TITLE
fix: ignore the 'B' augmentation character when reading CIE info.

### DIFF
--- a/src/eh_frame.cc
+++ b/src/eh_frame.cc
@@ -189,8 +189,16 @@ void ReadEhFrame(string_view data, RangeSink* sink) {
                 ReadEncodedPointer(encoding, true, &entry, nullptr, sink);
             break;
           }
+          case 'G':
+          case 'B': {
+            // Some compilers emit a G/B augmentation character.  We don't
+            // currently handle it, but it's not a fatal error.
+            // ref: https://github.com/llvm-mirror/libunwind/commit/0930d6cee2caf71685a84b648f85a2f80bc182c4
+            break;
+          }
           default:
-            THROW("Unexepcted augmentation character");
+            std::string aug_char(1, aug_string[0]);
+            THROWF("Unexepcted augmentation character: $0", aug_char);
         }
         aug_string.remove_prefix(1);
       }


### PR DESCRIPTION
Some compilers emit a B augmentation character that Bloaty does not currently handle. This patch ignores it because it is not useful for binary size analysis and should not break the process.

ref: https://github.com/llvm-mirror/libunwind/commit/0930d6cee2caf71685a84b648f85a2f80bc182c4