### PR TITLE
Disable assertions in demumble sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,33 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}/src")
 include_directories(third_party/demumble/third_party/llvm/include)
 include_directories(third_party/demumble/third_party/swift/include)
 
+
+# Demumble has an open issue build as a library.
+# See https://github.com/nico/demumble/issues/39
+set(DEMUMBLE_SOURCES
+    third_party/demumble/third_party/llvm/lib/Demangle/Demangle.cpp
+    third_party/demumble/third_party/llvm/lib/Demangle/DLangDemangle.cpp
+    third_party/demumble/third_party/llvm/lib/Demangle/ItaniumDemangle.cpp
+    third_party/demumble/third_party/llvm/lib/Demangle/MicrosoftDemangle.cpp
+    third_party/demumble/third_party/llvm/lib/Demangle/MicrosoftDemangleNodes.cpp
+    third_party/demumble/third_party/llvm/lib/Demangle/RustDemangle.cpp
+    third_party/demumble/third_party/swift/lib/Demangling/Context.cpp
+    third_party/demumble/third_party/swift/lib/Demangling/CrashReporter.cpp
+    third_party/demumble/third_party/swift/lib/Demangling/Demangler.cpp
+    third_party/demumble/third_party/swift/lib/Demangling/Errors.cpp
+    third_party/demumble/third_party/swift/lib/Demangling/ManglingUtils.cpp
+    third_party/demumble/third_party/swift/lib/Demangling/NodeDumper.cpp
+    third_party/demumble/third_party/swift/lib/Demangling/NodePrinter.cpp
+    third_party/demumble/third_party/swift/lib/Demangling/OldDemangler.cpp
+    third_party/demumble/third_party/swift/lib/Demangling/OldRemangler.cpp
+    third_party/demumble/third_party/swift/lib/Demangling/Punycode.cpp
+    third_party/demumble/third_party/swift/lib/Demangling/Remangler.cpp
+)
+
+set_source_files_properties(
+  ${DEMUMBLE_SOURCES}
+  PROPERTIES COMPILE_DEFINITIONS NDEBUG)
+
 # Baseline build flags.
 if(MSVC)
   set(CMAKE_CXX_FLAGS "/EHsc /wd4018 /D_CRT_SECURE_NO_WARNINGS /DNOMINMAX")
@@ -389,26 +416,7 @@ add_library(libbloaty STATIC
     src/util.h
     src/webassembly.cc
 
-    # Demumble has an open issue build as a library.
-    # See https://github.com/nico/demumble/issues/39
-
-    third_party/demumble/third_party/llvm/lib/Demangle/Demangle.cpp
-    third_party/demumble/third_party/llvm/lib/Demangle/DLangDemangle.cpp
-    third_party/demumble/third_party/llvm/lib/Demangle/ItaniumDemangle.cpp
-    third_party/demumble/third_party/llvm/lib/Demangle/MicrosoftDemangle.cpp
-    third_party/demumble/third_party/llvm/lib/Demangle/MicrosoftDemangleNodes.cpp
-    third_party/demumble/third_party/llvm/lib/Demangle/RustDemangle.cpp
-    third_party/demumble/third_party/swift/lib/Demangling/Context.cpp
-    third_party/demumble/third_party/swift/lib/Demangling/CrashReporter.cpp
-    third_party/demumble/third_party/swift/lib/Demangling/Demangler.cpp
-    third_party/demumble/third_party/swift/lib/Demangling/Errors.cpp
-    third_party/demumble/third_party/swift/lib/Demangling/ManglingUtils.cpp
-    third_party/demumble/third_party/swift/lib/Demangling/NodeDumper.cpp
-    third_party/demumble/third_party/swift/lib/Demangling/NodePrinter.cpp
-    third_party/demumble/third_party/swift/lib/Demangling/OldDemangler.cpp
-    third_party/demumble/third_party/swift/lib/Demangling/OldRemangler.cpp
-    third_party/demumble/third_party/swift/lib/Demangling/Punycode.cpp
-    third_party/demumble/third_party/swift/lib/Demangling/Remangler.cpp
+    ${DEMUMBLE_SOURCES}
     )
 set_property(TARGET libbloaty PROPERTY FOLDER "bloaty")
 

--- a/tests/wasm/malformed_function_name.test
+++ b/tests/wasm/malformed_function_name.test
@@ -1,0 +1,19 @@
+# RUN: %yaml2obj %s -o %t.wasm
+# RUN: %bloaty -d symbols %t.wasm | %FileCheck %s
+
+# CHECK: _TMXfZD
+
+--- !WASM
+FileHeader:
+  Version: 0x1
+Sections:
+  - Type: CODE
+    Functions:
+      - Index: 0
+        Locals: []
+        Body: 0B
+  - Type: CUSTOM
+    Name: name
+    FunctionNames:
+      - Index: 0
+        Name: "_TMXfZD\0"


### PR DESCRIPTION
Turn off assertions when building `demumble` sources by specifying
`NDEBUG`. This fixes an issue tripping up fuzzing, in this case
`demumble` already handles the issue gracefully.

Fixes https://github.com/google/bloaty/issues/457