### PR TITLE
Fix infinite loop in ReadEhFrameHdr when table_enc is omit

### DIFF
--- a/src/eh_frame.cc
+++ b/src/eh_frame.cc
@@ -247,6 +247,10 @@ void ReadEhFrameHdr(string_view data, RangeSink* sink) {
   uint64_t fde_count =
       ReadEncodedPointer(fde_count_enc, true, &data, base, sink);
 
+  if (table_enc == DW_EH_PE_omit) {
+    return;
+  }
+
   for (uint64_t i = 0; i < fde_count; i++) {
     string_view entry_data = data;
     uint64_t initial_location =

--- a/tests/elf/eh_frame_hdr_table_enc_omit.test
+++ b/tests/elf/eh_frame_hdr_table_enc_omit.test
@@ -1,0 +1,24 @@
+# Test that bloaty handles DW_EH_PE_omit in .eh_frame_hdr table_enc correctly
+# when fde_count is large. This prevents an infinite loop.
+# RUN: %yaml2obj %s -o %t.o
+# RUN: %bloaty %t.o -d symbols | %FileCheck %s
+
+# CHECK: TOTAL
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_REL
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .eh_frame_hdr
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC ]
+    # version=1
+    # eh_frame_ptr_enc=DW_EH_PE_udata4(0x03)
+    # fde_count_enc=DW_EH_PE_udata4(0x03)
+    # table_enc=DW_EH_PE_omit(0xff)
+    # eh_frame_ptr=0x00000000 (4 bytes)
+    # fde_count=0x7fffffff (4 bytes, large value)
+    Content:         '010303ff00000000fffffff7'


### PR DESCRIPTION
When table_enc is DW_EH_PE_omit (0xff) in .eh_frame_hdr, ReadEncodedPointer returns 0 without advancing the data pointer. If fde_count is large (e.g. from a fuzzed binary), this leads to an infinite loop in ReadEhFrameHdr as it attempts to read fde_count entries.

This change adds a check to return early from ReadEhFrameHdr if table_enc is DW_EH_PE_omit, as there is no table to read in this case.

Fixes #453.