### PR TITLE
Fix missing <list> include

### DIFF
--- a/src/bloaty.h
+++ b/src/bloaty.h
@@ -25,6 +25,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 
+#include <list>
 #include <memory>
 #include <set>
 #include <string>


### PR DESCRIPTION
`bloaty.h` uses `std::list` but doesn't include `<list>`, this can cause compilation errors in some build environments.