### PR TITLE
Fix padding handling in note parsing resulting in "region out-of-bounds"

### DIFF
--- a/src/elf.cc
+++ b/src/elf.cc
@@ -427,7 +427,7 @@ void ElfFile::Section::ReadRelocationWithAddend(Elf64_Word index,
 }
 
 void ElfFile::NoteIter::Next() {
-  if (remaining_.empty()) {
+  if (remaining_.size() < sizeof(Elf_Note)) {
     done_ = true;
     return;
   }


### PR DESCRIPTION
The actual note content might not be well-aligned, so the linker might pad the section. In this case, `remaining_` will _not_ be empty, but it might not be big enough to read a full `Elf_Note` header, resulting in an out-of-bounds access.

This fixes failures on some binaries resulting in
> bloaty: region out-of-bounds

In particular, this happens with Qt binaries which embed `.note.qt.metadata` section with pretty much arbitrary internal length.

---

I've run tests locally, and no new tests fail (my local run fails `EmptyObjectFile`, `SimpleObjectFile` and `SimpleArchiveFile`, but that also happens on master).