### PR TITLE
Fix --source-filter summary message never being printed.

### DIFF
--- a/src/bloaty.cc
+++ b/src/bloaty.cc
@@ -827,12 +827,11 @@ void RollupOutput::PrettyPrint(const OutputOptions& options,
 
   uint64_t file_filtered = 0;
   uint64_t vm_filtered = 0;
-  uint64_t filtered = 0;
   if (ShowFile(options)) {
-    filtered += toplevel_row_.filtered_size.file;
+    file_filtered = toplevel_row_.filtered_size.file;
   }
   if (ShowVM(options)) {
-    filtered += toplevel_row_.filtered_size.vm;
+    vm_filtered = toplevel_row_.filtered_size.vm;
   }
 
   if (vm_filtered == 0 && file_filtered == 0) {

--- a/tests/source-filter.test
+++ b/tests/source-filter.test
@@ -1,0 +1,22 @@
+# Test that --source-filter displays the filtering summary message.
+
+# RUN: rm -rf %t && mkdir -p %t
+# RUN: %yaml2obj %S/macho/no-dsym.test -o %t/test_binary
+
+# Test 1: Both domains - should show file and vm omitted sizes
+# RUN: %bloaty %t/test_binary -d sections --source-filter="text" | %FileCheck --check-prefix=BOTH %s
+# BOTH: __TEXT,__text
+# BOTH: TOTAL
+# BOTH: Filtering enabled (source_filter); omitted
+
+# Test 2: VM only - should show vm omitted size
+# RUN: %bloaty %t/test_binary -d sections --domain=vm --source-filter="text" | %FileCheck --check-prefix=VM %s
+# VM: __TEXT,__text
+# VM: TOTAL
+# VM: Filtering enabled (source_filter); omitted
+
+# Test 3: File only - should show file omitted size
+# RUN: %bloaty %t/test_binary -d sections --domain=file --source-filter="text" | %FileCheck --check-prefix=FILE %s
+# FILE: __TEXT,__text
+# FILE: TOTAL
+# FILE: Filtering enabled (source_filter); omitted


### PR DESCRIPTION
Fixes #490

The filtered size variables were accidentally misassigned in 08a77271 causing the "Filtering enabled (source_filter); omitted..." message to never appear. 