### PR TITLE
Fix heap-buffer-overflow in DWARF v5 line info parser

### DIFF
--- a/src/dwarf/line_info.cc
+++ b/src/dwarf/line_info.cc
@@ -264,6 +264,9 @@ void LineInfoReader::SeekToOffset(uint64_t offset, uint8_t address_size) {
           }
         }
       }
+      if (file_name.directory_index >= include_directories_.size()) {
+        THROW("directory index out of range");
+      }
       filenames_.push_back(file_name);
     }
   }


### PR DESCRIPTION
## Summary

The DWARF v5 file name parsing path in `LineInfoReader` (`src/dwarf/line_info.cc`) does not validate that `directory_index` is within the bounds of `include_directories_` before pushing the file name entry. The DWARF v4 code path already has this check (line 149), but the v5 path is missing it.

When `GetExpandedFilename()` later uses the unchecked `directory_index` to look up `include_directories_[directory_index]`, a crafted ELF file with an out-of-range `directory_index` triggers a heap-buffer-overflow read.

## Fix

Add the same bounds check that exists in the v4 path:

```cpp
if (file_name.directory_index >= include_directories_.size()) {
  THROW("directory index out of range");
}
```

This is inserted right before `filenames_.push_back(file_name)` in the v5 parsing loop (after all entry format fields have been read), so the index is fully resolved before validation.

## Reproduction

A minimal crafted ELF with a DWARF v5 `.debug_line` section containing a `directory_index` larger than the directory count triggers the bug. Under AddressSanitizer:

```
==PID==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x...
READ of size 16 at 0x...
    #0 bloaty::dwarf::LineInfoReader::GetExpandedFilename(...)
```

## Test plan

- Verified the fix rejects the crafted PoC with `"directory index out of range"` instead of crashing
- Verified normal ELF binaries with valid DWARF v5 line info still parse correctly