### PR TITLE
Validate source map source indices

### DIFF
--- a/src/source_map.cc
+++ b/src/source_map.cc
@@ -108,6 +108,15 @@ static int ReadBase64VLQSegment(std::string_view* data, int32_t (&values)[5]) {
   THROW("Unterminated Base64VLQ segment");
 }
 
+static std::string_view GetSourceFile(
+    const std::vector<std::string_view>& sources, int64_t source_file) {
+  if (source_file < 0 ||
+      static_cast<size_t>(source_file) >= sources.size()) {
+    THROW("source map source file index out of range");
+  }
+  return sources[source_file];
+}
+
 class VlqSegment {
  public:
   int32_t col;
@@ -149,7 +158,7 @@ void ForEachVLQSegment(std::string_view* data,
     THROW("Source file info expected in first VLQ segment");
   }
   int32_t col = values[0];
-  int32_t source_file = values[1];
+  int64_t source_file = values[1];
   int32_t source_line = values[2];
   int32_t source_col = values[3];
 
@@ -167,7 +176,8 @@ void ForEachVLQSegment(std::string_view* data,
     int new_values_count = ReadBase64VLQSegment(data, values);
     if (values_count >= 4) {
       segment_func(VlqSegment(col, values[0],
-                              sources[source_file], source_line, source_col));
+                              GetSourceFile(sources, source_file), source_line,
+                              source_col));
     }
     values_count = new_values_count;
     col += values[0];
@@ -236,4 +246,3 @@ std::unique_ptr<ObjectFile> TryOpenSourceMapFile(
 }
 
 }  // namespace bloaty
-

--- a/tests/wasm/sourcemap_invalid_source_index.test
+++ b/tests/wasm/sourcemap_invalid_source_index.test
@@ -1,0 +1,21 @@
+# RUN: %yaml2obj %s -o %t.obj
+# RUN: echo "{\"version\":3,\"sources\":[\"a.js\",\"b.js\"],\"mappings\":\"AACA,AgxTAA,AAAA\"}" > %t.map
+# RUN: not %bloaty --raw-map %t.obj --source-map=./sourcemap.wasm.map=%t.map -d compileunits 2>&1 | %FileCheck %s
+
+# CHECK: bloaty: source map source file index out of range
+
+--- !WASM
+FileHeader:
+  Version:         0x1
+Sections:
+  - Type:            CODE
+    Functions:
+      - Index:           0
+        Locals:
+          - Type:            I32
+            Count:           1
+        Body:            41000B
+  - Type:            CUSTOM
+    Name:            sourceMappingURL
+    # ./sourcemap.wasm.map
+    Payload:         142E2F736F757263656D61702E7761736D2E6D6170


### PR DESCRIPTION
Fixes #489.

`ForEachVLQSegment()` accumulates source-file deltas from attacker-controlled source-map mappings and then uses the result to index the `sources` vector without validating the index. A malformed source map can therefore drive an out-of-range vector read while Bloaty processes compile-unit or inline source-map data.

This change validates the accumulated source-file index before looking up the source name and rejects negative or out-of-range values. The source-file accumulator is also widened to avoid wrapping before the bounds check.

I added a wasm source-map regression test using the malformed mapping from the issue:

```text
AACA,AgxTAA,AAAA
```

Instead of indexing outside `sources`, Bloaty now reports:

```text
source map source file index out of range
```

Local verification:

```bash
cmake --build build-asan --target bloaty -j2
python3 /usr/bin/lit -sv build-asan/tests \
  --param bloaty=build-asan/bloaty \
  --filter sourcemap_invalid_source_index
python3 /usr/bin/lit -sv build-asan/tests \
  --param bloaty=build-asan/bloaty \
  --filter 'wasm/sourcemap'
python3 /usr/bin/lit -sv build-asan/tests \
  --param bloaty=build-asan/bloaty
git diff --check HEAD~1..HEAD
```

Results:

```text
Targeted regression lit test passed.
Source-map lit subset passed 4/4.
Full lit suite passed 54/54.
git diff --check HEAD~1..HEAD passed.
```

Before/after repro:

- Baseline parent commit aborts on the malformed source map with a vector bounds assertion.
- This patch returns the controlled error `source map source file index out of range`.
