### PR TITLE
fix out-of-bounds read for zero-length ELF note name

### DIFF
--- a/src/elf.cc
+++ b/src/elf.cc
@@ -443,7 +443,7 @@ void ElfFile::NoteIter::Next() {
   name_ = StrictSubstr(remaining_, 0, note.n_namesz);
 
   // Size might include NULL terminator.
-  if (name_[name_.size() - 1] == 0) {
+  if (!name_.empty() && name_[name_.size() - 1] == 0) {
     name_ = name_.substr(0, name_.size() - 1);
   }
 


### PR DESCRIPTION
A note with n_namesz=0 makes name_.size()-1 underflow in NoteIter::Next, so the trailing-NUL check reads name_[SIZE_MAX] out of bounds; guard it with !name_.empty().