### PR TITLE
bounds-check source file index in source map vlq parser

### DIFF
--- a/src/source_map.cc
+++ b/src/source_map.cc
@@ -166,6 +166,10 @@ void ForEachVLQSegment(std::string_view* data,
 
     int new_values_count = ReadBase64VLQSegment(data, values);
     if (values_count >= 4) {
+      if (source_file < 0 ||
+          static_cast<size_t>(source_file) >= sources.size()) {
+        THROW("source map mapping references out-of-range source index");
+      }
       segment_func(VlqSegment(col, values[0],
                               sources[source_file], source_line, source_col));
     }


### PR DESCRIPTION
Spotted this reading the source map parser. The sources array is bounds-checked nowhere before ForEachVLQSegment indexes it with sources[source_file], but source_file comes straight out of the mappings VLQ stream and is a signed int32 that can be negative or past the end of sources. A crafted .map walks off the vector. Reject the out-of-range index before the lookup, the same way the surrounding parser already throws on malformed input.