### PR TITLE
bounds check source index before indexing sources in source maps

### DIFF
--- a/src/source_map.cc
+++ b/src/source_map.cc
@@ -166,6 +166,10 @@ void ForEachVLQSegment(std::string_view* data,
 
     int new_values_count = ReadBase64VLQSegment(data, values);
     if (values_count >= 4) {
+      if (source_file < 0 ||
+          static_cast<size_t>(source_file) >= sources.size()) {
+        THROWF("source index $0 out of range in source map", source_file);
+      }
       segment_func(VlqSegment(col, values[0],
                               sources[source_file], source_line, source_col));
     }

--- a/tests/wasm/sourcemap_bad_source_index.test
+++ b/tests/wasm/sourcemap_bad_source_index.test
@@ -1,0 +1,24 @@
+# RUN: %yaml2obj %s -o %t.obj
+# RUN: echo "{\"version\": 3, \"sources\": [\"test1.java\"], \"names\": [], \"mappings\": \"AAAA,AgqjGAA,AAAA\"}" > %t.map
+# RUN: not %bloaty --raw-map %t.obj --source-map=./sourcemap.wasm.map=%t.map -d compileunits 2>&1 | %FileCheck %s
+
+# The second VLQ segment moves the source index to 100000, far past the single
+# entry in "sources".
+
+--- !WASM
+FileHeader:
+  Version:         0x1
+Sections:
+  - Type:            CODE
+    Functions:
+      - Index:           0
+        Locals:
+          - Type:            I32
+            Count:           13
+        Body:            41002100200028028880808000210141052102200120026A210341002104200428028C808080002105200320056A2106410021072007280280808080002108200820066A21094100210A200A200936028080808000418480808000210B200B210C200C0F0B
+  - Type:            CUSTOM
+    Name:            sourceMappingURL
+    # ./sourcemap.wasm.map
+    Payload:         142E2F736F757263656D61702E7761736D2E6D6170
+
+# CHECK: source index 100000 out of range in source map


### PR DESCRIPTION
Bloaty reads source maps supplied with --source-map, and those are untrusted input just like the object files. In ForEachVLQSegment the source index starts as the second value of the first VLQ segment and is then accumulated from the deltas of every later segment, all of which come straight out of the mappings string, so it can be moved to any int32 value including negative ones. Nothing compares it against sources.size() before sources[source_file] runs, and since that is std::vector::operator[] the read simply goes wherever the index points, after which VlqSegment copies the resulting string_view into a std::string and follows a pointer that was never part of the vector. I hit it while feeding mutated maps at the wasm sourcemap tests: with sources holding a single entry, mappings of "AAAA,AgqjGAA,AAAA" moves the index to 100000 and bloaty dies on a bad address inside ForEachVLQSegment, while a smaller delta quietly prints a garbage file name instead. Checking the index against the vector at the point of use closes both, and throwing there keeps it consistent with how the rest of the parsers report malformed input. Test added alongside the existing wasm source map tests; it fails before the change and passes after, and the rest of the suite is unaffected.