### PR TITLE
avoid out-of-bounds read on empty ELF note name

### DIFF
--- a/src/elf.cc
+++ b/src/elf.cc
@@ -443,7 +443,7 @@ void ElfFile::NoteIter::Next() {
   name_ = StrictSubstr(remaining_, 0, note.n_namesz);
 
   // Size might include NULL terminator.
-  if (name_[name_.size() - 1] == 0) {
+  if (!name_.empty() && name_[name_.size() - 1] == 0) {
     name_ = name_.substr(0, name_.size() - 1);
   }
 

--- a/tests/elf/note_empty_name.test
+++ b/tests/elf/note_empty_name.test
@@ -1,0 +1,22 @@
+# Test that bloaty handles an ELF note with n_namesz == 0 without reading out
+# of bounds. GetBuildId() walks the notes in every SHT_NOTE section; a note
+# with an empty name used to index name_[name_.size() - 1] on an empty view.
+
+# RUN: %yaml2obj %s -o %t.so
+# RUN: %bloaty %t.so -d sections | %FileCheck %s
+
+# CHECK: TOTAL
+
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS64
+  Data:            ELFDATA2LSB
+  Type:            ET_DYN
+  Machine:         EM_X86_64
+Sections:
+  - Name:            .note.empty
+    Type:            SHT_NOTE
+    Flags:           [ SHF_ALLOC ]
+    AddressAlign:    0x0000000000000004
+    # n_namesz=0, n_descsz=0, n_type=1
+    Content:         '000000000000000001000000'


### PR DESCRIPTION
GetBuildId walks the notes in every SHT_NOTE section, and each note's name comes from NoteIter::Next as name_ = StrictSubstr(remaining_, 0, note.n_namesz). The n_namesz field is read straight out of the note header, so it is attacker-controlled just like the rest of the object. When a note carries n_namesz == 0 the name_ view is empty, and the very next line checks name_[name_.size() - 1] to trim a trailing NUL, so name_.size() - 1 wraps to SIZE_MAX and the operator[] reads outside the view. I hit it feeding a crafted ET_DYN with a single empty-name note; a build with libc++ hardening traps in NoteIter::Next, and it is on the default path since GetBuildId runs for every non-object input. Guarding the trim with !name_.empty() closes it while leaving the normal case (a name ending in NUL) unchanged. Added a yaml2obj regression alongside the other elf tests.