### PR TITLE
reject overlong base64 vlq in source map parser

### DIFF
--- a/src/source_map.cc
+++ b/src/source_map.cc
@@ -65,6 +65,11 @@ static int32_t ReadBase64VLQ(std::string_view* data) {
   const char* limit = ptr + data->size();
   while (ptr < limit) {
     auto ch = *(ptr++);
+    // A well-formed VLQ encoding a 32-bit value never shifts past the width of
+    // `value`; anything more is malformed input and would shift by >= 32.
+    if (shift >= 32) {
+      THROW("Base64VLQ value out of range");
+    }
     // Base64 characters A-Z, a-f do not have the continuation bit set and are
     // the last digit.
     if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch < 'g')) {

--- a/tests/wasm/sourcemap_vlq_overflow.test
+++ b/tests/wasm/sourcemap_vlq_overflow.test
@@ -1,0 +1,15 @@
+# RUN: %yaml2obj %s -o %t.obj
+# RUN: echo "{\"version\": 3, \"sources\": [\"test.js\"], \"names\": [], \"mappings\": \"ggggggggA\"}" > %t.map
+# RUN: not %bloaty --raw-map %t.obj --source-map=./sourcemap.wasm.map=%t.map -d compileunits 2>&1 | %FileCheck %s
+
+# An overlong Base64 VLQ shifts a 32-bit accumulator by 32 or more bits.
+# CHECK: Base64VLQ value out of range
+
+--- !WASM
+FileHeader:
+  Version:         0x1
+Sections:
+  - Type:            CUSTOM
+    Name:            sourceMappingURL
+    # ./sourcemap.wasm.map
+    Payload:         142E2F736F757263656D61702E7761736D2E6D6170


### PR DESCRIPTION
An overlong Base64 VLQ shifts a 32-bit accumulator by 32 or more bits in ReadBase64VLQ:
- the loop grows `shift` by 5 for every continuation digit with no cap, unlike the LEB128 readers in webassembly.cc and dwarf/dwarf_util.cc which stop at a max shift
- a `mappings` string with 8+ continuation digits reaches shift 35, so `digit << shift` on the uint32 is an out-of-range left shift (UBSan: `shift exponent 35 is too large for 32-bit type`)
- reachable from any source map bloaty loads via `--source-map`, so a crafted `.map` triggers it under the undefined-sanitizer fuzz config

Reject once shift hits 32; a valid 32-bit VLQ never gets there, so valid maps are unaffected. Added a regression test under tests/wasm.