### PR TITLE
cast to unsigned char before isdigit in ar member parsing

### DIFF
--- a/src/elf.cc
+++ b/src/elf.cc
@@ -672,7 +672,7 @@ bool ArFile::MemberReader::ReadMember(MemberFile* file) {
     } else if (file_id[1] == '/') {
       file->file_type = MemberFile::kLongFilenameTable;
       long_filenames_ = file->contents;
-    } else if (isdigit(file_id[1])) {
+    } else if (isdigit(static_cast<unsigned char>(file_id[1]))) {
       size_t offset = StringViewToSize(file_id.substr(1));
       size_t end = long_filenames_.find('/', offset);
 


### PR DESCRIPTION
Bloaty can open static `.a` archives, and ArFile::MemberReader::ReadMember reads the 16-byte member name straight out of the file. When a name begins with '/' the code calls isdigit(file_id[1]) to distinguish a long-filename reference from the symbol table and the long-name table. file_id[1] is a plain char, so on a platform where char is signed a name byte with the high bit set reaches isdigit as a negative int, and the ctype functions are only defined for arguments representable as unsigned char or EOF. I ran into it building a small `.a` by hand whose member name was "/\x80"; glibc happens to fold that to the correct answer, but a stricter CRT indexes its ctype table with the negative value and reads outside it. Casting to unsigned char before the call keeps the argument in range. This is the only ctype call in the tree, so nothing else needs the same fix.