### PR TITLE
tests: Ensure malformed symbol remains invalid

### DIFF
--- a/tests/wasm/malformed_function_name.test
+++ b/tests/wasm/malformed_function_name.test
@@ -1,7 +1,7 @@
 # RUN: %yaml2obj %s -o %t.wasm
 # RUN: %bloaty -d symbols %t.wasm | %FileCheck %s
 
-# CHECK: _TMXfZD
+# CHECK: _Zinvalid_name
 
 --- !WASM
 FileHeader:
@@ -16,4 +16,4 @@ Sections:
     Name: name
     FunctionNames:
       - Index: 0
-        Name: "_TMXfZD\0"
+        Name: "_Zinvalid_name\0"


### PR DESCRIPTION
Newer versions of the Swift demangler return true on `isSwiftSymbol("_TMXfZD")` due to `_T` being a real legacy prefix for Swift mangling. This change updates the symbol name to ensure that it is invalid, and is not accidentally parsed by the Swift demangler.