### PR TITLE
ci: Pin windows runner to windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Using `windows-latest` for the Windows CI checks results in the following failure:

```
CMake Error at CMakeLists.txt:47 (project):
  Generator

    Visual Studio 17 2022

  could not find any instance of Visual Studio.
```

Pinning the windows runner to windows-2022 resolves this issue.