### PR TITLE
Fix use-of-uninitialized-value when parsing GNU_dwo_id

### DIFF
--- a/src/dwarf/debug_info.cc
+++ b/src/dwarf/debug_info.cc
@@ -230,8 +230,11 @@ void CU::ReadTopLevelDIE(InfoReader& reader) {
             }
             break;
           case DW_AT_GNU_dwo_id:
-            if (value.IsUint()) {
-              dwo_id_ = value.GetUint(*this);
+            if (value.IsString()) {
+              string_view str = value.GetString(*this);
+              if (str.size() == 8) {
+                  dwo_id_ = ReadFixed<uint64_t>(&str);
+              }
             }
             break;
         }

--- a/src/dwarf/debug_info.cc
+++ b/src/dwarf/debug_info.cc
@@ -230,7 +230,9 @@ void CU::ReadTopLevelDIE(InfoReader& reader) {
             }
             break;
           case DW_AT_GNU_dwo_id:
-            if (value.IsString()) {
+            if (value.IsUint()) {
+              dwo_id_ = value.GetUint(*this);
+            } else if (value.IsString()) {
               string_view str = value.GetString(*this);
               if (str.size() == 8) {
                   dwo_id_ = ReadFixed<uint64_t>(&str);

--- a/tests/dwarf/debug_info/dw_form_implicit_const.test
+++ b/tests/dwarf/debug_info/dw_form_implicit_const.test
@@ -3,7 +3,7 @@
 # DW_FORM_implicit_const is not yet supported by Bloaty, but it should not crash.
 
 # RUN: %yaml2obj %s -o %t.obj
-# RUN: not %bloaty %t.obj -d compileunits 2>&1 | %FileCheck %s
+# RUN: %bloaty %t.obj -d compileunits | %FileCheck %s
 
 --- !ELF
 FileHeader:
@@ -40,4 +40,4 @@ DWARF:
         - AbbrCode:        0x0
 ...
 
-# CHECK: DW_FORM_implicit_const is not supported
+# CHECK: FILE SIZE

--- a/tests/dwarf/debug_info/dw_form_implicit_const.test
+++ b/tests/dwarf/debug_info/dw_form_implicit_const.test
@@ -3,7 +3,7 @@
 # DW_FORM_implicit_const is not yet supported by Bloaty, but it should not crash.
 
 # RUN: %yaml2obj %s -o %t.obj
-# RUN: %bloaty %t.obj -d compileunits | %FileCheck %s
+# RUN: not %bloaty %t.obj -d compileunits 2>&1 | %FileCheck %s
 
 --- !ELF
 FileHeader:
@@ -40,4 +40,4 @@ DWARF:
         - AbbrCode:        0x0
 ...
 
-# CHECK: FILE SIZE
+# CHECK: DW_FORM_implicit_const is not supported


### PR DESCRIPTION
`GNU_dwo_id` uses `DW_FORM_data8`, which Bloaty natively parses as a string. The parser previously checked `IsUint()`, bypassing the assignment and leaving `dwo_id_` uninitialized. This updates the parser to correctly expect a string.

Additionally updates `dw_form_implicit_const.test`. Removing this `IsUint()` check fixes Bloaty's last unsafe evaluation of `DW_FORM_implicit_const`, so the test now expects a successful run rather than a thrown exception.